### PR TITLE
Add directional_information argument to tidy() methods

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,7 +30,7 @@ Imports:
     abind,
     chk,
     coda,
-    extras,
+    extras (>= 0.9.0.9000),
     generics,
     lifecycle,
     purrr,
@@ -45,13 +45,15 @@ Suggests:
     mcmcr,
     rmarkdown,
     testthat
-VignetteBuilder: 
+VignetteBuilder:
     knitr
-RdMacros: 
+RdMacros:
     lifecycle
+Remotes:
+    poissonconsulting/extras
 Config/Needs/website: poissonconsulting/poissontemplate
 Config/testthat/edition: 3
 Encoding: UTF-8
 Language: en-US
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.2.9000
+Config/roxygen2/version: 8.0.0.9000

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -150,33 +150,43 @@ import(lifecycle)
 import(term)
 import(universals)
 importFrom(abind,abind)
-importFrom(coda,as.mcmc)
-importFrom(coda,as.mcmc.list)
-importFrom(coda,thin)
-importFrom(extras,fill_all)
-importFrom(extras,fill_na)
-importFrom(extras,lower)
-importFrom(extras,pvalue)
-importFrom(extras,svalue)
-importFrom(extras,upper)
-importFrom(extras,zscore)
+importFrom(coda,
+  as.mcmc,
+  as.mcmc.list,
+  thin
+)
+importFrom(extras,
+  fill_all,
+  fill_na,
+  lower,
+  pvalue,
+  svalue,
+  upper,
+  zscore
+)
 importFrom(generics,tidy)
 importFrom(purrr,transpose)
-importFrom(stats,aggregate)
-importFrom(stats,median)
-importFrom(term,as.term)
-importFrom(term,as_term)
-importFrom(term,complete_terms)
-importFrom(universals,"pars<-")
-importFrom(universals,bind_iterations)
-importFrom(universals,collapse_chains)
-importFrom(universals,estimates)
-importFrom(universals,nchains)
-importFrom(universals,niters)
-importFrom(universals,npdims)
-importFrom(universals,nsims)
-importFrom(universals,nterms)
-importFrom(universals,pars)
-importFrom(universals,pdims)
-importFrom(universals,set_pars)
-importFrom(universals,split_chains)
+importFrom(stats,
+  aggregate,
+  median
+)
+importFrom(term,
+  as.term,
+  as_term,
+  complete_terms
+)
+importFrom(universals,
+  "pars<-",
+  bind_iterations,
+  collapse_chains,
+  estimates,
+  nchains,
+  niters,
+  npdims,
+  nsims,
+  nterms,
+  pars,
+  pdims,
+  set_pars,
+  split_chains
+)

--- a/R/params.R
+++ b/R/params.R
@@ -18,6 +18,11 @@
 #' @param parameters A character vector (or NULL) of the parameters to subset by.
 #' @param iterations An integer vector (or NULL) of the iterations to subset by.
 #' @param simplify A flag specifying whether to drop sd and zscore columns.
+#' @param directional_information A flag specifying whether the svalue column
+#' should be calculated using [extras::directional_information()] instead of
+#' [extras::svalue()].
+#' The default value will change from `FALSE` to `TRUE` in a future release;
+#' set the argument explicitly to avoid the deprecation warning.
 #' @param silent A flag specifying whether to suppress warning messages.
 #' @param by_chain A flag specifying whether to aggregate by chains.
 #' @keywords internal

--- a/R/tidy.R
+++ b/R/tidy.R
@@ -1,21 +1,46 @@
 #' @export
 generics::tidy
 
+warn_default_directional_information <- function(env = parent.frame(), user_env = parent.frame(2)) {
+  lifecycle::deprecate_soft(
+    "0.5.0",
+    "tidy(directional_information = 'should be explicitly set')",
+    details = paste(
+      "The default value of `directional_information` will change from",
+      "`FALSE` to `TRUE` in a future release."
+    ),
+    env = env,
+    user_env = user_env
+  )
+}
+
 #' @inheritParams params
 #' @inherit generics::tidy
 #' @export
-tidy.mcmc <- function(x, simplify = FALSE, ...) {
+tidy.mcmc <- function(x, simplify = FALSE, directional_information = FALSE, ...) {
   chk_unused(...)
-  tidy(as_nlists(x), simplify = simplify)
+  if (missing(directional_information)) {
+    warn_default_directional_information()
+  }
+  tidy(as_nlists(x),
+    simplify = simplify,
+    directional_information = directional_information
+  )
 }
 
 #' @inheritParams params
 #' @inherit generics::tidy
 #'
 #' @export
-tidy.mcmc.list <- function(x, simplify = FALSE, ...) {
+tidy.mcmc.list <- function(x, simplify = FALSE, directional_information = FALSE, ...) {
   chk_unused(...)
-  tidy(as_nlists(x), simplify = simplify)
+  if (missing(directional_information)) {
+    warn_default_directional_information()
+  }
+  tidy(as_nlists(x),
+    simplify = simplify,
+    directional_information = directional_information
+  )
 }
 
 #' @inheritParams params
@@ -26,11 +51,19 @@ tidy.mcmc.list <- function(x, simplify = FALSE, ...) {
 #' tidy(nlists(
 #'   nlist(x = 1, y = 4:6),
 #'   nlist(x = 3, y = 7:9)
-#' ), simplify = TRUE)
-tidy.nlists <- function(x, simplify = FALSE, ...) {
+#' ), simplify = TRUE, directional_information = FALSE)
+#' tidy(nlists(
+#'   nlist(x = 1, y = 4:6),
+#'   nlist(x = 3, y = 7:9)
+#' ), simplify = TRUE, directional_information = TRUE)
+tidy.nlists <- function(x, simplify = FALSE, directional_information = FALSE, ...) {
   chk_flag(simplify)
+  chk_flag(directional_information)
   chk_unused(...)
 
+  if (missing(directional_information)) {
+    warn_default_directional_information()
+  }
   if (!simplify) {
     lifecycle::deprecate_warn("0.3.1", "tidy(simplify = 'must be TRUE')")
   }
@@ -62,7 +95,8 @@ tidy.nlists <- function(x, simplify = FALSE, ...) {
     zscore <- unname(unlist(estimates(x, zscore)))
     lower <- unname(unlist(estimates(x, lower)))
     upper <- unname(unlist(estimates(x, upper)))
-    svalue <- unname(unlist(estimates(x, svalue)))
+    svalue_fun <- if (directional_information) extras::directional_information else svalue
+    svalue <- unname(unlist(estimates(x, svalue_fun)))
   }
   if (simplify) {
     return(tibble::tibble(

--- a/man/aggregate.nlist.Rd
+++ b/man/aggregate.nlist.Rd
@@ -24,7 +24,7 @@ aggregate(nlist(x = 1:9))
 aggregate(nlist(y = 3:5, zz = matrix(1:9, 3)), fun = function(x) x[1])
 }
 \seealso{
-Other aggregate: 
-\code{\link{aggregate.nlists}()}
+Other aggregate:
+\code{\link[=aggregate.nlists]{aggregate.nlists()}}
 }
 \concept{aggregate}

--- a/man/aggregate.nlists.Rd
+++ b/man/aggregate.nlists.Rd
@@ -27,7 +27,7 @@ with \code{nchains} \code{\link[=nlist_object]{nlist_object()}}s.
 aggregate(nlists(nlist(x = 1:3), nlist(x = 2:4)))
 }
 \seealso{
-Other aggregate: 
-\code{\link{aggregate.nlist}()}
+Other aggregate:
+\code{\link[=aggregate.nlist]{aggregate.nlist()}}
 }
 \concept{aggregate}

--- a/man/as_mcmc.Rd
+++ b/man/as_mcmc.Rd
@@ -44,9 +44,9 @@ as_mcmc(nlists(
 ))
 }
 \seealso{
-\code{\link[coda:mcmc]{coda::as.mcmc()}}
+\code{\link[coda:as.mcmc]{coda::as.mcmc()}}
 
-Other mcmc: 
-\code{\link{as_mcmc_list}()}
+Other mcmc:
+\code{\link[=as_mcmc_list]{as_mcmc_list()}}
 }
 \concept{mcmc}

--- a/man/as_mcmc_list.Rd
+++ b/man/as_mcmc_list.Rd
@@ -43,7 +43,7 @@ as_mcmc_list(nlists(
 ))
 }
 \seealso{
-Other mcmc: 
-\code{\link{as_mcmc}()}
+Other mcmc:
+\code{\link[=as_mcmc]{as_mcmc()}}
 }
 \concept{mcmc}

--- a/man/as_nlist.Rd
+++ b/man/as_nlist.Rd
@@ -56,7 +56,7 @@ as_nlist(list(x = 1:4))
 as_nlist(c(`a[2]` = 3, `a[1]` = 2))
 }
 \seealso{
-Other coerce: 
-\code{\link{as_nlists}()}
+Other coerce:
+\code{\link[=as_nlists]{as_nlists()}}
 }
 \concept{coerce}

--- a/man/as_nlists.Rd
+++ b/man/as_nlists.Rd
@@ -44,7 +44,7 @@ Coerce an R object to an \code{\link[=nlists_object]{nlists_object()}}.
 as_nlists(list(nlist(x = c(1, 5)), nlist(x = c(2, 3)), nlist(x = c(3, 2))))
 }
 \seealso{
-Other coerce: 
-\code{\link{as_nlist}()}
+Other coerce:
+\code{\link[=as_nlist]{as_nlist()}}
 }
 \concept{coerce}

--- a/man/as_term.mcmc.Rd
+++ b/man/as_term.mcmc.Rd
@@ -18,11 +18,11 @@ Coerce to a Term Vector
 as_term(as_mcmc(nlist(x = matrix(1:4, ncol = 2))))
 }
 \seealso{
-Other coerce term: 
-\code{\link{as_term.nlist}()},
-\code{\link{as_term.nlists}()},
-\code{\link{as_term_frame}()},
-\code{\link{as_term_frame.nlist}()},
-\code{\link{as_term_frame.nlists}()}
+Other coerce term:
+\code{\link[=as_term.nlist]{as_term.nlist()}},
+\code{\link[=as_term.nlists]{as_term.nlists()}},
+\code{\link[=as_term_frame]{as_term_frame()}},
+\code{\link[=as_term_frame.nlist]{as_term_frame.nlist()}},
+\code{\link[=as_term_frame.nlists]{as_term_frame.nlists()}}
 }
 \concept{coerce term}

--- a/man/as_term.nlist.Rd
+++ b/man/as_term.nlist.Rd
@@ -18,11 +18,11 @@ Coerce to a Term Vector
 as_term(nlist(x = matrix(1:4, ncol = 2)))
 }
 \seealso{
-Other coerce term: 
-\code{\link{as_term.mcmc}()},
-\code{\link{as_term.nlists}()},
-\code{\link{as_term_frame}()},
-\code{\link{as_term_frame.nlist}()},
-\code{\link{as_term_frame.nlists}()}
+Other coerce term:
+\code{\link[=as_term.mcmc]{as_term.mcmc()}},
+\code{\link[=as_term.nlists]{as_term.nlists()}},
+\code{\link[=as_term_frame]{as_term_frame()}},
+\code{\link[=as_term_frame.nlist]{as_term_frame.nlist()}},
+\code{\link[=as_term_frame.nlists]{as_term_frame.nlists()}}
 }
 \concept{coerce term}

--- a/man/as_term.nlists.Rd
+++ b/man/as_term.nlists.Rd
@@ -18,11 +18,11 @@ Coerce to a Term Vector
 as_term(nlists(nlist(x = matrix(1:4, ncol = 2))))
 }
 \seealso{
-Other coerce term: 
-\code{\link{as_term.mcmc}()},
-\code{\link{as_term.nlist}()},
-\code{\link{as_term_frame}()},
-\code{\link{as_term_frame.nlist}()},
-\code{\link{as_term_frame.nlists}()}
+Other coerce term:
+\code{\link[=as_term.mcmc]{as_term.mcmc()}},
+\code{\link[=as_term.nlist]{as_term.nlist()}},
+\code{\link[=as_term_frame]{as_term_frame()}},
+\code{\link[=as_term_frame.nlist]{as_term_frame.nlist()}},
+\code{\link[=as_term_frame.nlists]{as_term_frame.nlists()}}
 }
 \concept{coerce term}

--- a/man/as_term_frame.Rd
+++ b/man/as_term_frame.Rd
@@ -21,11 +21,11 @@ value and in the case of an nlists object an integer
 vector called samples. It includes the original nlist or nlists object.
 }
 \seealso{
-Other coerce term: 
-\code{\link{as_term.mcmc}()},
-\code{\link{as_term.nlist}()},
-\code{\link{as_term.nlists}()},
-\code{\link{as_term_frame.nlist}()},
-\code{\link{as_term_frame.nlists}()}
+Other coerce term:
+\code{\link[=as_term.mcmc]{as_term.mcmc()}},
+\code{\link[=as_term.nlist]{as_term.nlist()}},
+\code{\link[=as_term.nlists]{as_term.nlists()}},
+\code{\link[=as_term_frame.nlist]{as_term_frame.nlist()}},
+\code{\link[=as_term_frame.nlists]{as_term_frame.nlists()}}
 }
 \concept{coerce term}

--- a/man/as_term_frame.nlist.Rd
+++ b/man/as_term_frame.nlist.Rd
@@ -22,11 +22,11 @@ and a value column.
 as_term_frame(nlist(x = 1, y = 4:6))
 }
 \seealso{
-Other coerce term: 
-\code{\link{as_term.mcmc}()},
-\code{\link{as_term.nlist}()},
-\code{\link{as_term.nlists}()},
-\code{\link{as_term_frame}()},
-\code{\link{as_term_frame.nlists}()}
+Other coerce term:
+\code{\link[=as_term.mcmc]{as_term.mcmc()}},
+\code{\link[=as_term.nlist]{as_term.nlist()}},
+\code{\link[=as_term.nlists]{as_term.nlists()}},
+\code{\link[=as_term_frame]{as_term_frame()}},
+\code{\link[=as_term_frame.nlists]{as_term_frame.nlists()}}
 }
 \concept{coerce term}

--- a/man/as_term_frame.nlists.Rd
+++ b/man/as_term_frame.nlists.Rd
@@ -25,11 +25,11 @@ as_term_frame(nlists(
 ))
 }
 \seealso{
-Other coerce term: 
-\code{\link{as_term.mcmc}()},
-\code{\link{as_term.nlist}()},
-\code{\link{as_term.nlists}()},
-\code{\link{as_term_frame}()},
-\code{\link{as_term_frame.nlist}()}
+Other coerce term:
+\code{\link[=as_term.mcmc]{as_term.mcmc()}},
+\code{\link[=as_term.nlist]{as_term.nlist()}},
+\code{\link[=as_term.nlists]{as_term.nlists()}},
+\code{\link[=as_term_frame]{as_term_frame()}},
+\code{\link[=as_term_frame.nlist]{as_term_frame.nlist()}}
 }
 \concept{coerce term}

--- a/man/collapse_chains.mcmc.Rd
+++ b/man/collapse_chains.mcmc.Rd
@@ -24,8 +24,8 @@ As mcmc objects can only have 1 chain the object is unchanged.
 collapse_chains(as_mcmc(nlist(x = 2)))
 }
 \seealso{
-Other collapse: 
-\code{\link{collapse_chains.nlist}()},
-\code{\link{collapse_chains.nlists}()}
+Other collapse:
+\code{\link[=collapse_chains.nlist]{collapse_chains.nlist()}},
+\code{\link[=collapse_chains.nlists]{collapse_chains.nlists()}}
 }
 \concept{collapse}

--- a/man/collapse_chains.nlist.Rd
+++ b/man/collapse_chains.nlist.Rd
@@ -24,8 +24,8 @@ As nlist objects can only have 1 chain the object is unchanged.
 collapse_chains(nlist(x = 2))
 }
 \seealso{
-Other collapse: 
-\code{\link{collapse_chains.mcmc}()},
-\code{\link{collapse_chains.nlists}()}
+Other collapse:
+\code{\link[=collapse_chains.mcmc]{collapse_chains.mcmc()}},
+\code{\link[=collapse_chains.nlists]{collapse_chains.nlists()}}
 }
 \concept{collapse}

--- a/man/collapse_chains.nlists.Rd
+++ b/man/collapse_chains.nlists.Rd
@@ -21,8 +21,8 @@ Collapses an MCMC object's chains into a single chain.
 collapse_chains(nlist(x = 2))
 }
 \seealso{
-Other collapse: 
-\code{\link{collapse_chains.mcmc}()},
-\code{\link{collapse_chains.nlist}()}
+Other collapse:
+\code{\link[=collapse_chains.mcmc]{collapse_chains.mcmc()}},
+\code{\link[=collapse_chains.nlist]{collapse_chains.nlist()}}
 }
 \concept{collapse}

--- a/man/fill_all.nlist.Rd
+++ b/man/fill_all.nlist.Rd
@@ -45,6 +45,6 @@ fill_all(nlist(x = c(2, NA), y = matrix(c(1:3, NA), nrow = 2)))
 fill_all(nlist(x = c(2, NA), y = matrix(c(1:3, NA), nrow = 2)), nas = FALSE)
 }
 \seealso{
-Other fill: 
-\code{\link[extras]{fill_na}()}
+Other fill:
+\code{\link[extras:fill_na]{fill_na()}}
 }

--- a/man/fill_all.nlists.Rd
+++ b/man/fill_all.nlists.Rd
@@ -45,6 +45,6 @@ fill_all(nlists(nlist(x = c(2, NA)), nlist(x = c(NA_real_, NA))))
 fill_all(nlists(nlist(x = c(2, NA)), nlist(x = c(NA_real_, NA))), nas = FALSE)
 }
 \seealso{
-Other fill: 
-\code{\link[extras]{fill_na}()}
+Other fill:
+\code{\link[extras:fill_na]{fill_na()}}
 }

--- a/man/fill_na.nlist.Rd
+++ b/man/fill_na.nlist.Rd
@@ -43,6 +43,6 @@ fill_na(nlist(x = c(2, NA), y = matrix(c(1:3, NA), nrow = 2)))
 fill_na(nlists(nlist(x = c(2, NA)), nlist(x = c(NA_real_, NA))))
 }
 \seealso{
-Other fill: 
-\code{\link[extras]{fill_all}()}
+Other fill:
+\code{\link[extras:fill_all]{fill_all()}}
 }

--- a/man/fill_na.nlists.Rd
+++ b/man/fill_na.nlists.Rd
@@ -42,6 +42,6 @@ not standard data.frames.
 fill_na(nlist(x = c(2, NA), y = matrix(c(1:3, NA), nrow = 2)))
 }
 \seealso{
-Other fill: 
-\code{\link[extras]{fill_all}()}
+Other fill:
+\code{\link[extras:fill_all]{fill_all()}}
 }

--- a/man/nlist-package.Rd
+++ b/man/nlist-package.Rd
@@ -20,6 +20,11 @@ Useful links:
 \author{
 \strong{Maintainer}: Joe Thorley \email{joe@poissonconsulting.ca} (\href{https://orcid.org/0000-0002-7683-4592}{ORCID})
 
+Authors:
+\itemize{
+  \item Joe Thorley \email{joe@poissonconsulting.ca} (\href{https://orcid.org/0000-0002-7683-4592}{ORCID})
+}
+
 Other contributors:
 \itemize{
   \item Kirill Müller (\href{https://orcid.org/0000-0002-1416-3412}{ORCID}) [contributor]

--- a/man/params.Rd
+++ b/man/params.Rd
@@ -37,6 +37,12 @@ for each term element.}
 
 \item{simplify}{A flag specifying whether to drop sd and zscore columns.}
 
+\item{directional_information}{A flag specifying whether the svalue column
+should be calculated using \code{\link[extras:directional_information]{extras::directional_information()}} instead of
+\code{\link[extras:svalue]{extras::svalue()}}.
+The default value will change from \code{FALSE} to \code{TRUE} in a future release;
+set the argument explicitly to avoid the deprecation warning.}
+
 \item{silent}{A flag specifying whether to suppress warning messages.}
 
 \item{by_chain}{A flag specifying whether to aggregate by chains.}

--- a/man/reexports.Rd
+++ b/man/reexports.Rd
@@ -43,16 +43,16 @@ These objects are imported from other packages. Follow the links
 below to see their documentation.
 
 \describe{
-  \item{coda}{\code{\link[coda:mcmc]{as.mcmc}}, \code{\link[coda:mcmc.list]{as.mcmc.list}}, \code{\link[coda]{thin}}}
+  \item{coda}{\code{\link[coda:as.mcmc]{as.mcmc()}}, \code{\link[coda:as.mcmc.list]{as.mcmc.list()}}, \code{\link[coda:thin]{thin()}}}
 
-  \item{extras}{\code{\link[extras]{fill_all}}, \code{\link[extras]{fill_na}}, \code{\link[extras]{lower}}, \code{\link[extras]{pvalue}}, \code{\link[extras]{svalue}}, \code{\link[extras]{upper}}, \code{\link[extras]{zscore}}}
+  \item{extras}{\code{\link[extras:fill_all]{fill_all()}}, \code{\link[extras:fill_na]{fill_na()}}, \code{\link[extras:lower]{lower()}}, \code{\link[extras:pvalue]{pvalue()}}, \code{\link[extras:svalue]{svalue()}}, \code{\link[extras:upper]{upper()}}, \code{\link[extras:zscore]{zscore()}}}
 
-  \item{generics}{\code{\link[generics]{tidy}}}
+  \item{generics}{\code{\link[generics:tidy]{tidy()}}}
 
-  \item{stats}{\code{\link[stats]{aggregate}}, \code{\link[stats]{median}}}
+  \item{stats}{\code{\link[stats:aggregate]{aggregate()}}, \code{\link[stats:median]{median()}}}
 
-  \item{term}{\code{\link[term:as_term]{as.term}}, \code{\link[term]{as_term}}, \code{\link[term]{complete_terms}}}
+  \item{term}{\code{\link[term:as_term]{as_term()}}, \code{\link[term:as.term]{as.term()}}, \code{\link[term:complete_terms]{complete_terms()}}}
 
-  \item{universals}{\code{\link[universals]{bind_iterations}}, \code{\link[universals]{collapse_chains}}, \code{\link[universals]{estimates}}, \code{\link[universals]{nchains}}, \code{\link[universals]{niters}}, \code{\link[universals]{npdims}}, \code{\link[universals]{nsims}}, \code{\link[universals]{nterms}}, \code{\link[universals]{pars}}, \code{\link[universals:set_pars]{pars<-}}, \code{\link[universals]{pdims}}, \code{\link[universals]{set_pars}}, \code{\link[universals]{split_chains}}}
+  \item{universals}{\code{\link[universals:bind_iterations]{bind_iterations()}}, \code{\link[universals:collapse_chains]{collapse_chains()}}, \code{\link[universals:estimates]{estimates()}}, \code{\link[universals:nchains]{nchains()}}, \code{\link[universals:niters]{niters()}}, \code{\link[universals:npdims]{npdims()}}, \code{\link[universals:nsims]{nsims()}}, \code{\link[universals:nterms]{nterms()}}, \code{\link[universals:pars]{pars()}}, \code{\link[universals:pars<-]{pars<-()}}, \code{\link[universals:pdims]{pdims()}}, \code{\link[universals:set_pars]{set_pars()}}, \code{\link[universals:split_chains]{split_chains()}}}
 }}
 

--- a/man/tidy.mcmc.Rd
+++ b/man/tidy.mcmc.Rd
@@ -4,12 +4,18 @@
 \alias{tidy.mcmc}
 \title{Turn an object into a tidy tibble}
 \usage{
-\method{tidy}{mcmc}(x, simplify = FALSE, ...)
+\method{tidy}{mcmc}(x, simplify = FALSE, directional_information = FALSE, ...)
 }
 \arguments{
 \item{x}{An object.}
 
 \item{simplify}{A flag specifying whether to drop sd and zscore columns.}
+
+\item{directional_information}{A flag specifying whether the svalue column
+should be calculated using \code{\link[extras:directional_information]{extras::directional_information()}} instead of
+\code{\link[extras:svalue]{extras::svalue()}}.
+The default value will change from \code{FALSE} to \code{TRUE} in a future release;
+set the argument explicitly to avoid the deprecation warning.}
 
 \item{...}{Unused.}
 }

--- a/man/tidy.mcmc.list.Rd
+++ b/man/tidy.mcmc.list.Rd
@@ -4,12 +4,18 @@
 \alias{tidy.mcmc.list}
 \title{Turn an object into a tidy tibble}
 \usage{
-\method{tidy}{mcmc.list}(x, simplify = FALSE, ...)
+\method{tidy}{mcmc.list}(x, simplify = FALSE, directional_information = FALSE, ...)
 }
 \arguments{
 \item{x}{An object.}
 
 \item{simplify}{A flag specifying whether to drop sd and zscore columns.}
+
+\item{directional_information}{A flag specifying whether the svalue column
+should be calculated using \code{\link[extras:directional_information]{extras::directional_information()}} instead of
+\code{\link[extras:svalue]{extras::svalue()}}.
+The default value will change from \code{FALSE} to \code{TRUE} in a future release;
+set the argument explicitly to avoid the deprecation warning.}
 
 \item{...}{Unused.}
 }

--- a/man/tidy.nlists.Rd
+++ b/man/tidy.nlists.Rd
@@ -4,12 +4,18 @@
 \alias{tidy.nlists}
 \title{Turn an object into a tidy tibble}
 \usage{
-\method{tidy}{nlists}(x, simplify = FALSE, ...)
+\method{tidy}{nlists}(x, simplify = FALSE, directional_information = FALSE, ...)
 }
 \arguments{
 \item{x}{An object.}
 
 \item{simplify}{A flag specifying whether to drop sd and zscore columns.}
+
+\item{directional_information}{A flag specifying whether the svalue column
+should be calculated using \code{\link[extras:directional_information]{extras::directional_information()}} instead of
+\code{\link[extras:svalue]{extras::svalue()}}.
+The default value will change from \code{FALSE} to \code{TRUE} in a future release;
+set the argument explicitly to avoid the deprecation warning.}
 
 \item{...}{Unused.}
 }
@@ -30,5 +36,9 @@ Turn an object into a tidy tibble
 tidy(nlists(
   nlist(x = 1, y = 4:6),
   nlist(x = 3, y = 7:9)
-), simplify = TRUE)
+), simplify = TRUE, directional_information = FALSE)
+tidy(nlists(
+  nlist(x = 1, y = 4:6),
+  nlist(x = 3, y = 7:9)
+), simplify = TRUE, directional_information = TRUE)
 }

--- a/tests/testthat/test-tidy.R
+++ b/tests/testthat/test-tidy.R
@@ -1,7 +1,7 @@
 test_that("tidy.nlists", {
   rlang::local_options(lifecycle_verbosity = "quiet")
 
-  lifecycle::expect_deprecated(tidy(nlists()))
+  lifecycle::expect_deprecated(tidy(nlists(), directional_information = FALSE))
 
   expect_identical(tidy(nlists()), structure(list(
     term = structure(character(0), class = c(
@@ -57,7 +57,7 @@ test_that("tidy.nlists", {
 })
 
 test_that("tidy.nlists", {
-  expect_identical(tidy(nlists(), simplify = TRUE), structure(list(
+  expect_identical(tidy(nlists(), simplify = TRUE, directional_information = FALSE), structure(list(
     term = structure(character(0), class = c(
       "term",
       "vctrs_vctr"
@@ -68,21 +68,21 @@ test_that("tidy.nlists", {
     "tbl", "data.frame"
   )))
   expect_equal(
-    tidy(nlists(nlist()), simplify = TRUE),
+    tidy(nlists(nlist()), simplify = TRUE, directional_information = FALSE),
     tibble::tibble(
       term = term(x = 0), estimate = numeric(0),
       lower = numeric(0), upper = numeric(0), svalue = numeric(0)
     )
   )
   expect_identical(
-    tidy(nlists(nlist(x = 2)), simplify = TRUE),
+    tidy(nlists(nlist(x = 2)), simplify = TRUE, directional_information = FALSE),
     tibble::tibble(
       term = term("x"), estimate = 2, lower = 2,
       upper = 2, svalue = 1
     )
   )
   expect_identical(
-    tidy(nlists(nlist(x = 2:4)), simplify = TRUE),
+    tidy(nlists(nlist(x = 2:4)), simplify = TRUE, directional_information = FALSE),
     tibble::tibble(
       term = term(x = 3), estimate = c(2, 3, 4),
       lower = c(
@@ -92,7 +92,7 @@ test_that("tidy.nlists", {
     )
   )
   expect_identical(
-    tidy(nlists(nlist(y = 1, s = 1:2)), simplify = TRUE),
+    tidy(nlists(nlist(y = 1, s = 1:2)), simplify = TRUE, directional_information = FALSE),
     tibble::tibble(
       term = term("y", s = 2), estimate = c(1, 1, 2),
       lower = c(
@@ -101,7 +101,7 @@ test_that("tidy.nlists", {
       ), upper = c(1, 1, 2), svalue = c(1, 1, 1)
     )
   )
-  expect_equal(tidy(nlists(nlist(x = 1, y = 1:2), nlist(x = 1, y = 3:4)), simplify = TRUE), tibble::tibble(
+  expect_equal(tidy(nlists(nlist(x = 1, y = 1:2), nlist(x = 1, y = 3:4)), simplify = TRUE, directional_information = FALSE), tibble::tibble(
     term = term("x" = 1, y = 2), estimate = c(1, 2, 3),
     lower = c(1, 1.05, 2.05), upper = c(1, 2.95, 3.95), svalue = c(
       1.58496250072116,
@@ -112,10 +112,60 @@ test_that("tidy.nlists", {
 
 test_that("tidy.mcmc", {
   nlists <- nlists(nlist(x = 1:3, y = matrix(1)))
-  expect_identical(tidy(as_mcmc(nlists), simplify = TRUE), tidy(nlists, simplify = TRUE))
+  expect_identical(
+    tidy(as_mcmc(nlists), simplify = TRUE, directional_information = FALSE),
+    tidy(nlists, simplify = TRUE, directional_information = FALSE)
+  )
 })
 
 test_that("tidy.mcmc.list", {
   nlists <- nlists(nlist(x = 1:3, y = matrix(1)))
-  expect_identical(tidy(as_mcmc_list(nlists), simplify = TRUE), tidy(nlists, simplify = TRUE))
+  expect_identical(
+    tidy(as_mcmc_list(nlists), simplify = TRUE, directional_information = FALSE),
+    tidy(nlists, simplify = TRUE, directional_information = FALSE)
+  )
+})
+
+test_that("tidy directional_information = TRUE", {
+  x <- nlists(nlist(x = 1, y = -2), nlist(x = 3, y = -4))
+  tidy_di <- tidy(x, simplify = TRUE, directional_information = TRUE)
+  tidy_svalue <- tidy(x, simplify = TRUE, directional_information = FALSE)
+
+  expect_identical(colnames(tidy_di), c("term", "estimate", "lower", "upper", "svalue"))
+  expect_identical(
+    tidy_di[c("term", "estimate", "lower", "upper")],
+    tidy_svalue[c("term", "estimate", "lower", "upper")]
+  )
+  expect_identical(tidy_di$svalue[tidy_di$term == "x"], extras::directional_information(c(1, 3)))
+  expect_identical(tidy_di$svalue[tidy_di$term == "y"], extras::directional_information(c(-2, -4)))
+  expect_identical(tidy_svalue$svalue[tidy_svalue$term == "x"], extras::svalue(c(1, 3)))
+
+})
+
+test_that("tidy directional_information = TRUE with simplify = FALSE", {
+  rlang::local_options(lifecycle_verbosity = "quiet")
+
+  x <- nlists(nlist(x = 1, y = -2), nlist(x = 3, y = -4))
+  tidy_full <- tidy(x, simplify = FALSE, directional_information = TRUE)
+  tidy_di <- tidy(x, simplify = TRUE, directional_information = TRUE)
+  expect_identical(tidy_full$svalue, tidy_di$svalue)
+})
+
+test_that("tidy directional_information = TRUE via mcmc and mcmc.list", {
+  nlists <- nlists(nlist(x = 1:3, y = matrix(1)))
+  expect_identical(
+    tidy(as_mcmc(nlists), simplify = TRUE, directional_information = TRUE),
+    tidy(nlists, simplify = TRUE, directional_information = TRUE)
+  )
+  expect_identical(
+    tidy(as_mcmc_list(nlists), simplify = TRUE, directional_information = TRUE),
+    tidy(nlists, simplify = TRUE, directional_information = TRUE)
+  )
+})
+
+test_that("tidy warns when directional_information is not explicitly set", {
+  lifecycle::expect_deprecated(
+    tidy(nlists(nlist(x = 2)), simplify = TRUE),
+    "directional_information"
+  )
 })


### PR DESCRIPTION
Ports the `directional_information` argument from poissonconsulting/mcmcr#71 and poissonconsulting/embr#117 to nlist's `tidy()` methods (`tidy.nlists()`, `tidy.mcmc()`, `tidy.mcmc.list()`).

- `directional_information = TRUE` calculates the `svalue` column with [`extras::directional_information()`](https://poissonconsulting.github.io/extras/reference/directional_information.html) instead of `extras::svalue()`; the column keeps its `svalue` name.
- The default is `FALSE`; leaving it unset is soft-deprecated (`lifecycle::deprecate_soft("0.5.0", ...)`) because the default will flip to `TRUE` in a future release, matching the mcmcr convention.
- `extras (>= 0.9.0.9000)` with a `Remotes:` entry, as in mcmcr.
- Existing tidy tests updated to set the argument explicitly; new tests verify the TRUE path against `extras::directional_information()` per term, consistency across the mcmc/mcmc.list methods, and the deprecation warning.

Note: `devtools::test()` shows 4 pre-existing failures in `test-c.R` / `test-chk.R` that also fail on unmodified `main` (verified in a clean worktree) and are unrelated to this change. All 30 tidy tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)