### PR TITLE
chore: Format with air

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -13,3 +13,5 @@
 ^LICENSE\.md$
 ^_pkgdown\.yml$
 ^README\.Rmd$
+^[.]?air[.]toml$
+^\.vscode$

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "Posit.air-vscode"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+  "[r]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "Posit.air-vscode"
+  },
+  "[quarto]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "quarto.quarto"
+  }
+}

--- a/R/aggregate.R
+++ b/R/aggregate.R
@@ -16,7 +16,8 @@ stats::aggregate
 #' aggregate(nlist(x = 1:9))
 #' aggregate(nlist(y = 3:5, zz = matrix(1:9, 3)), fun = function(x) x[1])
 aggregate.nlist <- function(x, fun = mean, ...) {
-  deprecate_warn("0.1.1",
+  deprecate_warn(
+    "0.1.1",
     what = "nlist::aggregate.nlist()",
     with = "nlist::estimates.nlist()"
   )
@@ -37,7 +38,8 @@ aggregate.nlist <- function(x, fun = mean, ...) {
 #' @examples
 #' aggregate(nlists(nlist(x = 1:3), nlist(x = 2:4)))
 aggregate.nlists <- function(x, fun = mean, ..., by_chain = FALSE) {
-  deprecate_warn("0.1.1",
+  deprecate_warn(
+    "0.1.1",
     what = "nlist::aggregate.nlists()",
     with = "nlist::estimates.nlists()"
   )
@@ -53,6 +55,8 @@ aggregate.nlists <- function(x, fun = mean, ..., by_chain = FALSE) {
   x <- lapply(x, FUN = aggregate, fun = fun, ..., by_chain = FALSE)
   names(x) <- NULL
   class(x) <- "nlists"
-  if (nchains > 1L) attr(x, "nchains") <- nchains
+  if (nchains > 1L) {
+    attr(x, "nchains") <- nchains
+  }
   x
 }

--- a/R/as-nlist.R
+++ b/R/as-nlist.R
@@ -16,7 +16,8 @@ as_nlist <- function(x, ...) {
 #' @rdname as_nlist
 #' @export
 as.nlist <- function(x, ...) {
-  deprecate_warn("0.1.1",
+  deprecate_warn(
+    "0.1.1",
     what = "nlist::as.nlist()",
     with = "nlist::as_nlist()"
   )
@@ -70,7 +71,9 @@ as_nlist.data.frame <- function(x, ...) as_nlist(as.list(x))
 #' @export
 as_nlist.mcmc <- function(x, ...) {
   chk_unused(...)
-  if (!identical(nrow(x), 1L)) abort_chk("`x` must have one iteration.")
+  if (!identical(nrow(x), 1L)) {
+    abort_chk("`x` must have one iteration.")
+  }
 
   x <- complete_terms(x)
 

--- a/R/as-nlists.R
+++ b/R/as-nlists.R
@@ -15,7 +15,8 @@ as_nlists <- function(x, ...) {
 #' @rdname as_nlist
 #' @export
 as.nlists <- function(x, ...) {
-  deprecate_warn("0.1.1",
+  deprecate_warn(
+    "0.1.1",
     what = "nlist::as.nlists()",
     with = "nlist::as_nlists()"
   )

--- a/R/as-term-frame.R
+++ b/R/as-term-frame.R
@@ -84,7 +84,9 @@ as_term_frame.nlists <- function(x, ...) {
       value = numeric(0)
     )))
   }
-  x <- mapply(as_term_frame_nlist_impl, x,
+  x <- mapply(
+    as_term_frame_nlist_impl,
+    x,
     sample = seq_along(x),
     SIMPLIFY = FALSE
   )

--- a/R/brackets.R
+++ b/R/brackets.R
@@ -13,7 +13,11 @@
     x <- as_nlists(x)
     return(x)
   }
-  if (!missing(i)) x <- subset(x, chains = i)
-  if (!missing(j)) x <- subset(x, iters = j)
+  if (!missing(i)) {
+    x <- subset(x, chains = i)
+  }
+  if (!missing(j)) {
+    x <- subset(x, iters = j)
+  }
   as_nlists(x)
 }

--- a/R/c.R
+++ b/R/c.R
@@ -10,7 +10,10 @@ c.nlist <- function(...) {
   }
   class(x) <- "nlist"
   if (anyDuplicated(names(x))) {
-    abort_chk("nlist objects must have distinctly named numeric elements in order to be concatenated.", tidy = FALSE)
+    abort_chk(
+      "nlist objects must have distinctly named numeric elements in order to be concatenated.",
+      tidy = FALSE
+    )
   }
   x
 }
@@ -35,7 +38,9 @@ c.nlist <- function(...) {
   x <- do.call("c", x)
   class(x) <- "nlists"
   chk_nlists(x, x_name = "...")
-  if (nchains > 1L) attr(x, "nchains") <- nchains
+  if (nchains > 1L) {
+    attr(x, "nchains") <- nchains
+  }
   return(x)
 }
 

--- a/R/chk.R
+++ b/R/chk.R
@@ -17,7 +17,9 @@ chk_nlist <- function(x, x_name = NULL) {
   if (vld_nlist(x)) {
     return(invisible())
   }
-  if (is.null(x_name)) x_name <- deparse_backtick_chk(substitute(x))
+  if (is.null(x_name)) {
+    x_name <- deparse_backtick_chk(substitute(x))
+  }
   chk_s3_class(x, "nlist", x_name = x_name)
   chk_named(x, x_name = x_name)
   x_name_names <- backtick_chk(p0("names(", unbacktick_chk(x_name), ")"))
@@ -40,14 +42,31 @@ chk_nlists <- function(x, x_name = NULL) {
   if (vld_nlists(x)) {
     return(invisible())
   }
-  if (is.null(x_name)) x_name <- deparse_backtick_chk(substitute(x))
+  if (is.null(x_name)) {
+    x_name <- deparse_backtick_chk(substitute(x))
+  }
   chk_s3_class(x, "nlists", x_name = x_name)
   chk_all(x, chk_nlist, x_name = x_name)
   if (!vld_all_identical(lapply(x, names))) {
-    abort_chk("nlist elements of ", x_name, " must have matching names.", tidy = FALSE)
+    abort_chk(
+      "nlist elements of ",
+      x_name,
+      " must have matching names.",
+      tidy = FALSE
+    )
   }
   if (!vld_all_identical(lapply(x, lapply, dims))) {
-    abort_chk("nlist elements of ", x_name, " must have matching dimensions.", tidy = FALSE)
+    abort_chk(
+      "nlist elements of ",
+      x_name,
+      " must have matching dimensions.",
+      tidy = FALSE
+    )
   }
-  abort_chk("nlist elements of ", x_name, " must have matching types.", tidy = FALSE)
+  abort_chk(
+    "nlist elements of ",
+    x_name,
+    " must have matching types.",
+    tidy = FALSE
+  )
 }

--- a/R/complete-terms.R
+++ b/R/complete-terms.R
@@ -29,7 +29,9 @@ complete_terms.mcmc <- function(x, silent = FALSE, ...) {
   x <- as.matrix(x)
   x <- x[, !is.na(colnames(x)), drop = FALSE]
   colnames(x) <- as.character(as_term(colnames(x), repair = TRUE))
-  if (!silent && anyNA(colnames(x))) wrn("invalid terms have been dropped")
+  if (!silent && anyNA(colnames(x))) {
+    wrn("invalid terms have been dropped")
+  }
   x <- x[, !is.na(colnames(x)), drop = FALSE]
   if (!ncol(x)) {
     return(coda::as.mcmc(x))

--- a/R/deprecated.R
+++ b/R/deprecated.R
@@ -12,7 +12,8 @@ NULL
 #' Replace by [is.numeric()]
 #' @export
 is.natomic <- function(x) {
-  deprecate_warn("0.1.1",
+  deprecate_warn(
+    "0.1.1",
     what = "nlist::is.natomic()",
     with = "nlist::is_numeric()"
   )
@@ -26,7 +27,8 @@ is.natomic <- function(x) {
 #' Replace by [is_nlist()]
 #' @export
 is.nlist <- function(x) {
-  deprecate_warn("0.1.1",
+  deprecate_warn(
+    "0.1.1",
     what = "nlist::is.nlist()",
     with = "nlist::is_nlist()"
   )
@@ -40,7 +42,8 @@ is.nlist <- function(x) {
 #' Replace by [is_nlists()]
 #' @export
 is.nlists <- function(x) {
-  deprecate_warn("0.1.1",
+  deprecate_warn(
+    "0.1.1",
     what = "nlist::is.nlists()",
     with = "nlist::is_nlists()"
   )

--- a/R/internal.R
+++ b/R/internal.R
@@ -11,7 +11,9 @@ aggregate_atomic_numerics <- function(x, fun, ...) {
   ndims <- length(dims)
   x <- abind(x, along = ndims + 1L)
   x <- apply(x, MARGIN = 1:ndims, FUN = fun, ...)
-  if (!identical(dims(x), dims)) abort_chk("`fun` must return a scalar.")
+  if (!identical(dims(x), dims)) {
+    abort_chk("`fun` must return a scalar.")
+  }
   x
 }
 
@@ -23,13 +25,17 @@ lapply_nlists <- function(x, FUN, ...) {
   nchains <- nchains(x)
   x <- lapply(x, FUN = FUN, ...)
   class(x) <- "nlists"
-  if (nchains > 1L) attr(x, "nchains") <- nchains
+  if (nchains > 1L) {
+    attr(x, "nchains") <- nchains
+  }
   x
 }
 
 set_dim <- function(x, value) {
   dim(x) <- value
-  if (length(value) == 1L) dim(x) <- NULL
+  if (length(value) == 1L) {
+    dim(x) <- NULL
+  }
   x
 }
 

--- a/R/pars.R
+++ b/R/pars.R
@@ -5,12 +5,19 @@ universals::pars
 #' @inheritParams params
 #' @export
 pars.mcmc <- function(x, scalar = NULL, terms = FALSE, ...) {
-  if (!is.null(scalar)) chk_flag(scalar)
+  if (!is.null(scalar)) {
+    chk_flag(scalar)
+  }
   chk_flag(terms)
   chk_unused(...)
 
   if (!missing(terms)) {
-    deprecate_warn("0.2.1", "nlist::pars(terms =)", details = "If `terms = TRUE` use `terms::pars_terms(as_term(x)) otherwise replace `pars(x, terms = FALSE)` with `pars(x)`.", id = "pars_terms")
+    deprecate_warn(
+      "0.2.1",
+      "nlist::pars(terms =)",
+      details = "If `terms = TRUE` use `terms::pars_terms(as_term(x)) otherwise replace `pars(x, terms = FALSE)` with `pars(x)`.",
+      id = "pars_terms"
+    )
   }
   x <- as_term(x)
   if (terms) {
@@ -23,12 +30,19 @@ pars.mcmc <- function(x, scalar = NULL, terms = FALSE, ...) {
 #' @inheritParams params
 #' @export
 pars.mcmc.list <- function(x, scalar = NULL, terms = FALSE, ...) {
-  if (!is.null(scalar)) chk_flag(scalar)
+  if (!is.null(scalar)) {
+    chk_flag(scalar)
+  }
   chk_flag(terms)
   chk_unused(...)
 
   if (!missing(terms)) {
-    deprecate_warn("0.2.1", "nlist::pars(terms =)", details = "If `terms = TRUE` use `terms::pars_terms(as_term(x)) otherwise replace `pars(x, terms = FALSE)` with `pars(x)`.", id = "pars_terms")
+    deprecate_warn(
+      "0.2.1",
+      "nlist::pars(terms =)",
+      details = "If `terms = TRUE` use `terms::pars_terms(as_term(x)) otherwise replace `pars(x, terms = FALSE)` with `pars(x)`.",
+      id = "pars_terms"
+    )
   }
   x <- x[[1]]
   x <- as_term(x)
@@ -45,12 +59,19 @@ pars.mcmc.list <- function(x, scalar = NULL, terms = FALSE, ...) {
 #' @examples
 #' pars(nlist(zz = 1, y = 3:6))
 pars.nlist <- function(x, scalar = NULL, terms = FALSE, ...) {
-  if (!is.null(scalar)) chk_flag(scalar)
+  if (!is.null(scalar)) {
+    chk_flag(scalar)
+  }
   chk_flag(terms)
   chk_unused(...)
 
   if (!missing(terms)) {
-    deprecate_warn("0.1.1", "nlist::pars(terms =)", details = "If `terms = TRUE` use `terms::pars_terms(as_term(x)) otherwise replace `pars(x, terms = FALSE)` with `pars(x)`.", id = "pars_terms")
+    deprecate_warn(
+      "0.1.1",
+      "nlist::pars(terms =)",
+      details = "If `terms = TRUE` use `terms::pars_terms(as_term(x)) otherwise replace `pars(x, terms = FALSE)` with `pars(x)`.",
+      id = "pars_terms"
+    )
   }
 
   if (is.null(scalar) && !terms) {
@@ -72,11 +93,18 @@ pars.nlist <- function(x, scalar = NULL, terms = FALSE, ...) {
 #' @examples
 #' pars(nlists(nlist(zz = 1, y = 3:6), nlist(zz = 4, y = 13:16)))
 pars.nlists <- function(x, scalar = NULL, terms = FALSE, ...) {
-  if (!is.null(scalar)) chk_flag(scalar)
+  if (!is.null(scalar)) {
+    chk_flag(scalar)
+  }
   chk_unused(...)
 
   if (!missing(terms)) {
-    deprecate_warn("0.1.1", "nlist::pars(terms =)", details = "If `terms = TRUE` use `terms::pars_terms(as_term(x)) otherwise replace `pars(x, terms = FALSE)` with `pars(x)`.", id = "pars_terms")
+    deprecate_warn(
+      "0.1.1",
+      "nlist::pars(terms =)",
+      details = "If `terms = TRUE` use `terms::pars_terms(as_term(x)) otherwise replace `pars(x, terms = FALSE)` with `pars(x)`.",
+      id = "pars_terms"
+    )
   }
   if (!length(x)) {
     return(character(0))

--- a/R/print.R
+++ b/R/print.R
@@ -20,12 +20,17 @@ print.nlists <- function(x, ...) {
     return(invisible(x))
   }
   nn <- length(x[[1]])
-  if (nn) print(unclass(estimates(x)))
+  if (nn) {
+    print(unclass(estimates(x)))
+  }
 
   str <- "an nlists object"
   nchains <- nchains(x)
   str <- p(str, if (nchains > 1) p("with", nchains, "chains of") else "of")
-  str <- p(str, if (n == 1) "an nlist object with" else p(n, "nlist objects each with"))
+  str <- p(
+    str,
+    if (n == 1) "an nlist object with" else p(n, "nlist objects each with")
+  )
   str <- p(str, if (nn == 1) "1 numeric element" else p(nn, "numeric elements"))
   cat(str)
   invisible(x)

--- a/R/relist-nlist.R
+++ b/R/relist-nlist.R
@@ -28,7 +28,8 @@ relist_nlist <- function(flesh, skeleton) {
 
   not_in_skeleton <- names(flesh)[!names(flesh) %in% names(skeleton)]
   if (length(not_in_skeleton)) {
-    abort_chk("The following `flesh` term%s %r not in `skeleton`: ",
+    abort_chk(
+      "The following `flesh` term%s %r not in `skeleton`: ",
       cc(not_in_skeleton, conj = " and "),
       n = length(not_in_skeleton)
     )

--- a/R/set-pars.R
+++ b/R/set-pars.R
@@ -36,7 +36,12 @@ set_pars.nlist <- function(x, value, ...) {
   chk_unused(...)
 
   if (!identical(npars(x), length(value))) {
-    abort_chk("`value` must be length ", npars(x), ", not %n.", n = length(value))
+    abort_chk(
+      "`value` must be length ",
+      npars(x),
+      ", not %n.",
+      n = length(value)
+    )
   }
 
   if (!length(x)) {

--- a/R/sort.R
+++ b/R/sort.R
@@ -1,5 +1,7 @@
 #' @export
-sort.mcmc <- function(x, ...) set_class(x[, order(as_term(x)), drop = FALSE], "mcmc")
+sort.mcmc <- function(x, ...) {
+  set_class(x[, order(as_term(x)), drop = FALSE], "mcmc")
+}
 
 #' @export
 sort.mcmc.list <- function(x, ...) set_class(lapply(x, sort), "mcmc.list")

--- a/R/split-chains.R
+++ b/R/split-chains.R
@@ -12,7 +12,9 @@ split_chains.nlists <- function(x, ...) {
   niters <- niters(x)
   n <- floor(niters / 2L)
 
-  if (n == 0) abort_chk("`x` must have at least two iterations.")
+  if (n == 0) {
+    abort_chk("`x` must have at least two iterations.")
+  }
 
   if (n < niters / 2L) {
     x <- x[-seq(niters, niters * nchains, by = niters)]

--- a/R/subset.R
+++ b/R/subset.R
@@ -13,16 +13,28 @@
 #' mcmc <- as_mcmc(nlist(beta = 1:2, theta = 1))
 #' subset(mcmc, pars = "beta")
 #' subset(mcmc, iters = c(1L, 1L))
-subset.mcmc <- function(x, iters = NULL, pars = NULL,
-                        iterations = NULL, parameters = NULL, ...) {
+subset.mcmc <- function(
+  x,
+  iters = NULL,
+  pars = NULL,
+  iterations = NULL,
+  parameters = NULL,
+  ...
+) {
   if (!missing(iterations)) {
-    deprecate_warn("0.2.1", "subset(iterations = )", "subset(iters = )",
+    deprecate_warn(
+      "0.2.1",
+      "subset(iterations = )",
+      "subset(iters = )",
       id = "subset_iterations"
     )
     iters <- iterations
   }
   if (!missing(parameters)) {
-    deprecate_warn("0.2.1", "subset(parameters = )", "subset(pars = )",
+    deprecate_warn(
+      "0.2.1",
+      "subset(parameters = )",
+      "subset(pars = )",
       id = "subset_parameters"
     )
     pars <- parameters
@@ -39,8 +51,12 @@ subset.mcmc <- function(x, iters = NULL, pars = NULL,
   }
   chk_unused(...)
 
-  if (!is.null(pars)) x <- x[, pars_terms(as_term(x)) %in% pars, drop = FALSE]
-  if (!is.null(iters)) x <- x[iters, , drop = FALSE]
+  if (!is.null(pars)) {
+    x <- x[, pars_terms(as_term(x)) %in% pars, drop = FALSE]
+  }
+  if (!is.null(iters)) {
+    x <- x[iters, , drop = FALSE]
+  }
   set_class(x, "mcmc")
 }
 
@@ -62,16 +78,29 @@ subset.mcmc <- function(x, iters = NULL, pars = NULL,
 #' ))
 #' subset(mcmc.list, pars = "beta")
 #' subset(mcmc.list, iters = c(1L, 1L))
-subset.mcmc.list <- function(x, chains = NULL, iters = NULL, pars = NULL,
-                             iterations = NULL, parameters = NULL, ...) {
+subset.mcmc.list <- function(
+  x,
+  chains = NULL,
+  iters = NULL,
+  pars = NULL,
+  iterations = NULL,
+  parameters = NULL,
+  ...
+) {
   if (!missing(iterations)) {
-    deprecate_warn("0.2.1", "subset(iterations = )", "subset(iters = )",
+    deprecate_warn(
+      "0.2.1",
+      "subset(iterations = )",
+      "subset(iters = )",
       id = "subset_iterations"
     )
     iters <- iterations
   }
   if (!missing(parameters)) {
-    deprecate_warn("0.2.1", "subset(parameters = )", "subset(pars = )",
+    deprecate_warn(
+      "0.2.1",
+      "subset(parameters = )",
+      "subset(pars = )",
       id = "subset_parameters"
     )
     pars <- parameters
@@ -141,18 +170,32 @@ subset.nlist <- function(x, pars = NULL, ...) {
 #' subset(nlists, iters = 1L)
 #' subset(nlists, iters = c(2L, 2L))
 subset.nlists <- function(x, chains = NULL, iters = NULL, pars = NULL, ...) {
-  if (!is.null(chains)) chk_subset(chains, 1:nchains(x))
-  if (!is.null(iters)) chk_subset(chains, 1:niters(x))
-  if (!is.null(pars)) chk_subset(pars, pars(x))
+  if (!is.null(chains)) {
+    chk_subset(chains, 1:nchains(x))
+  }
+  if (!is.null(iters)) {
+    chk_subset(chains, 1:niters(x))
+  }
+  if (!is.null(pars)) {
+    chk_subset(pars, pars(x))
+  }
   chk_unused(...)
 
-  if (!is.null(pars)) x <- lapply_nlists(x, subset, pars = pars)
+  if (!is.null(pars)) {
+    x <- lapply_nlists(x, subset, pars = pars)
+  }
   x <- split_by_chains(x)
-  if (!is.null(chains)) x <- x[chains]
+  if (!is.null(chains)) {
+    x <- x[chains]
+  }
   nchains <- length(x)
-  if (!is.null(iters)) x <- lapply(x, function(x, iter) x[iter], iter = iters)
+  if (!is.null(iters)) {
+    x <- lapply(x, function(x, iter) x[iter], iter = iters)
+  }
   x <- .c_nlists(x)
-  if (nchains > 1L) attr(x, "nchains") <- nchains
+  if (nchains > 1L) {
+    attr(x, "nchains") <- nchains
+  }
   names(x) <- NULL
   x
 }

--- a/R/tidy.R
+++ b/R/tidy.R
@@ -1,7 +1,10 @@
 #' @export
 generics::tidy
 
-warn_default_directional_information <- function(env = parent.frame(), user_env = parent.frame(2)) {
+warn_default_directional_information <- function(
+  env = parent.frame(),
+  user_env = parent.frame(2)
+) {
   lifecycle::deprecate_soft(
     "0.5.0",
     "tidy(directional_information = 'should be explicitly set')",
@@ -17,12 +20,18 @@ warn_default_directional_information <- function(env = parent.frame(), user_env 
 #' @inheritParams params
 #' @inherit generics::tidy
 #' @export
-tidy.mcmc <- function(x, simplify = FALSE, directional_information = FALSE, ...) {
+tidy.mcmc <- function(
+  x,
+  simplify = FALSE,
+  directional_information = FALSE,
+  ...
+) {
   chk_unused(...)
   if (missing(directional_information)) {
     warn_default_directional_information()
   }
-  tidy(as_nlists(x),
+  tidy(
+    as_nlists(x),
     simplify = simplify,
     directional_information = directional_information
   )
@@ -32,12 +41,18 @@ tidy.mcmc <- function(x, simplify = FALSE, directional_information = FALSE, ...)
 #' @inherit generics::tidy
 #'
 #' @export
-tidy.mcmc.list <- function(x, simplify = FALSE, directional_information = FALSE, ...) {
+tidy.mcmc.list <- function(
+  x,
+  simplify = FALSE,
+  directional_information = FALSE,
+  ...
+) {
   chk_unused(...)
   if (missing(directional_information)) {
     warn_default_directional_information()
   }
-  tidy(as_nlists(x),
+  tidy(
+    as_nlists(x),
     simplify = simplify,
     directional_information = directional_information
   )
@@ -56,7 +71,12 @@ tidy.mcmc.list <- function(x, simplify = FALSE, directional_information = FALSE,
 #'   nlist(x = 1, y = 4:6),
 #'   nlist(x = 3, y = 7:9)
 #' ), simplify = TRUE, directional_information = TRUE)
-tidy.nlists <- function(x, simplify = FALSE, directional_information = FALSE, ...) {
+tidy.nlists <- function(
+  x,
+  simplify = FALSE,
+  directional_information = FALSE,
+  ...
+) {
   chk_flag(simplify)
   chk_flag(directional_information)
   chk_unused(...)
@@ -78,14 +98,21 @@ tidy.nlists <- function(x, simplify = FALSE, directional_information = FALSE, ..
 
     if (simplify) {
       return(tibble::tibble(
-        term = term, estimate = estimate,
-        lower = lower, upper = upper, svalue = svalue
+        term = term,
+        estimate = estimate,
+        lower = lower,
+        upper = upper,
+        svalue = svalue
       ))
     }
     return(tibble::tibble(
-      term = term, estimate = estimate,
-      sd = sd, zscore = zscore,
-      lower = lower, upper = upper, svalue = svalue
+      term = term,
+      estimate = estimate,
+      sd = sd,
+      zscore = zscore,
+      lower = lower,
+      upper = upper,
+      svalue = svalue
     ))
   } else {
     estimate <- unlist(estimates(x, median))
@@ -95,20 +122,30 @@ tidy.nlists <- function(x, simplify = FALSE, directional_information = FALSE, ..
     zscore <- unname(unlist(estimates(x, zscore)))
     lower <- unname(unlist(estimates(x, lower)))
     upper <- unname(unlist(estimates(x, upper)))
-    svalue_fun <- if (directional_information) extras::directional_information else svalue
+    svalue_fun <- if (directional_information) {
+      extras::directional_information
+    } else {
+      svalue
+    }
     svalue <- unname(unlist(estimates(x, svalue_fun)))
   }
   if (simplify) {
     return(tibble::tibble(
-      term = term, estimate = estimate,
+      term = term,
+      estimate = estimate,
       lower = lower,
-      upper = upper, svalue = svalue
+      upper = upper,
+      svalue = svalue
     ))
   }
 
   tibble::tibble(
-    term = term, estimate = estimate,
-    sd = sd, zscore = zscore, lower = lower,
-    upper = upper, svalue = svalue
+    term = term,
+    estimate = estimate,
+    sd = sd,
+    zscore = zscore,
+    lower = lower,
+    upper = upper,
+    svalue = svalue
   )
 }

--- a/R/unlist-nlist.R
+++ b/R/unlist-nlist.R
@@ -12,7 +12,9 @@
 unlist_nlist <- function(x) {
   chk_s3_class(x, "nlist")
   y <- unlist(unclass(x))
-  if (is.null(y)) y <- numeric(0)
+  if (is.null(y)) {
+    y <- numeric(0)
+  }
   y <- as.numeric(y)
   names(y) <- as_term(x)
   y
@@ -32,7 +34,9 @@ unlist_nlist <- function(x) {
 unlist.nlist <- function(x, recursive = TRUE, use.names = TRUE) {
   chk_flag(use.names)
   x <- unlist_nlist(x)
-  if (!use.names) x <- unname(x)
+  if (!use.names) {
+    x <- unname(x)
+  }
   x
 }
 

--- a/R/vld.R
+++ b/R/vld.R
@@ -10,8 +10,12 @@
 #' vld_nlist(nlist(x = 1))
 #' try(vld_nlist(list(x = 1)))
 vld_nlist <- function(x) {
-  vld_s3_class(x, "nlist") && vld_named(x) && vld_pars(names(x)) &&
-    vld_not_any_na(names(x)) && vld_unique(names(x)) && vld_all(x, vld_numeric)
+  vld_s3_class(x, "nlist") &&
+    vld_named(x) &&
+    vld_pars(names(x)) &&
+    vld_not_any_na(names(x)) &&
+    vld_unique(names(x)) &&
+    vld_all(x, vld_numeric)
 }
 
 #' @describeIn vld_nlist Validate nlists Object
@@ -24,7 +28,8 @@ vld_nlist <- function(x) {
 #' vld_nlists(nlists(nlist(x = 1)))
 #' vld_nlists(1)
 vld_nlists <- function(x) {
-  vld_s3_class(x, "nlists") && vld_all(x, vld_nlist) &&
+  vld_s3_class(x, "nlists") &&
+    vld_all(x, vld_nlist) &&
     vld_all_identical(lapply(x, names)) &&
     vld_all_identical(lapply(x, lapply, dims)) &&
     vld_all_identical(lapply(x, lapply, typesof))

--- a/air.toml
+++ b/air.toml
@@ -1,0 +1,7 @@
+[format]
+line-width = 80
+indent-width = 2
+indent-style = "space"
+line-ending = "auto"
+persistent-line-breaks = true
+default-exclude = true

--- a/scripts/build.R
+++ b/scripts/build.R
@@ -5,9 +5,11 @@ styler::style_pkg(
   filetype = c("R", "Rmd")
 )
 
-lintr::lint_package(linters = linters_with_defaults(
-  line_length_linter = line_length_linter(1000),
-  object_name_linter = object_name_linter(regexes = ".*"))
+lintr::lint_package(
+  linters = linters_with_defaults(
+    line_length_linter = line_length_linter(1000),
+    object_name_linter = object_name_linter(regexes = ".*")
+  )
 )
 
 lintr::lint_package()

--- a/tests/testthat/test-aggregate.R
+++ b/tests/testthat/test-aggregate.R
@@ -3,9 +3,18 @@ test_that("aggregate.nlist", {
   expect_identical(aggregate(nlist()), structure(list(), .Names = character(0)))
   expect_identical(aggregate(nlist(x = 1)), list(x = 1))
   expect_identical(aggregate(nlist(x = 1:2)), list(x = 1.5))
-  expect_identical(aggregate(nlist(x = 1:2), fun = function(x) x[1]), list(x = 1L))
-  expect_identical(aggregate(nlist(x = matrix(1:9, 3)), fun = function(x) x[1]), list(x = 1L))
-  expect_identical(aggregate(nlist(x = 1:3, y = matrix(1:9, 3))), list(x = 2, y = 5))
+  expect_identical(
+    aggregate(nlist(x = 1:2), fun = function(x) x[1]),
+    list(x = 1L)
+  )
+  expect_identical(
+    aggregate(nlist(x = matrix(1:9, 3)), fun = function(x) x[1]),
+    list(x = 1L)
+  )
+  expect_identical(
+    aggregate(nlist(x = 1:3, y = matrix(1:9, 3))),
+    list(x = 2, y = 5)
+  )
 
   expect_error(
     aggregate(nlist(x = 1:2), fun = identity),
@@ -24,26 +33,47 @@ test_that("aggregate.nlists", {
     aggregate(nlists(nlist())),
     structure(list(), .Names = character(0), class = "nlist")
   )
-  expect_identical(aggregate(nlists(nlist(x = 1), nlist(x = 2))), nlist(x = 1.5))
+  expect_identical(
+    aggregate(nlists(nlist(x = 1), nlist(x = 2))),
+    nlist(x = 1.5)
+  )
   expect_identical(
     aggregate(nlists(
       nlist(x = matrix(1:9, 3)),
       nlist(x = matrix(2:10, 3))
     )),
-    structure(list(x = structure(c(
-      1.5, 2.5, 3.5, 4.5, 5.5, 6.5,
-      7.5, 8.5, 9.5
-    ), .Dim = c(3L, 3L))), class = "nlist")
+    structure(
+      list(
+        x = structure(
+          c(
+            1.5,
+            2.5,
+            3.5,
+            4.5,
+            5.5,
+            6.5,
+            7.5,
+            8.5,
+            9.5
+          ),
+          .Dim = c(3L, 3L)
+        )
+      ),
+      class = "nlist"
+    )
   )
 })
 
 test_that("aggregate.nlists", {
   rlang::local_options(lifecycle_verbosity = "quiet")
   expect_error(
-    aggregate(nlists(
-      nlist(x = matrix(1:9, 3)),
-      nlist(x = matrix(2:10, 3))
-    ), fun = identity),
+    aggregate(
+      nlists(
+        nlist(x = matrix(1:9, 3)),
+        nlist(x = matrix(2:10, 3))
+      ),
+      fun = identity
+    ),
     "^`fun` must return a scalar[.]$",
     class = "chk_error"
   )
@@ -57,21 +87,45 @@ test_that("aggregate.nlists by_chain = TRUE", {
   )
   expect_identical(
     aggregate(nlists(nlist()), by_chain = TRUE),
-    structure(list(structure(list(), .Names = character(0), class = "nlist")), class = "nlists")
+    structure(
+      list(structure(list(), .Names = character(0), class = "nlist")),
+      class = "nlists"
+    )
   )
   expect_identical(
     aggregate(nlists(nlist(x = 1), nlist(x = 2)), by_chain = TRUE),
     structure(list(structure(list(x = 1.5), class = "nlist")), class = "nlists")
   )
   expect_identical(
-    aggregate(nlists(
-      nlist(x = matrix(1:9, 3)),
-      nlist(x = matrix(2:10, 3))
-    ), by_chain = TRUE),
-    structure(list(structure(list(x = structure(c(
-      1.5, 2.5,
-      3.5, 4.5, 5.5, 6.5, 7.5, 8.5, 9.5
-    ), .Dim = c(3L, 3L))), class = "nlist")), class = "nlists")
+    aggregate(
+      nlists(
+        nlist(x = matrix(1:9, 3)),
+        nlist(x = matrix(2:10, 3))
+      ),
+      by_chain = TRUE
+    ),
+    structure(
+      list(structure(
+        list(
+          x = structure(
+            c(
+              1.5,
+              2.5,
+              3.5,
+              4.5,
+              5.5,
+              6.5,
+              7.5,
+              8.5,
+              9.5
+            ),
+            .Dim = c(3L, 3L)
+          )
+        ),
+        class = "nlist"
+      )),
+      class = "nlists"
+    )
   )
   nlists <- nlists(nlist(x = matrix(1:9, 3)), nlist(x = matrix(2:10, 3)))
   attr(nlists, "nchains") <- 2L

--- a/tests/testthat/test-as-list.R
+++ b/tests/testthat/test-as-list.R
@@ -1,15 +1,36 @@
 test_that("as_list_unnamed_nlist", {
-  expect_identical(as_list_unnamed_default(nlist()), structure(list(), .Names = character(0)))
+  expect_identical(
+    as_list_unnamed_default(nlist()),
+    structure(list(), .Names = character(0))
+  )
   expect_identical(as_list_unnamed_default(nlist(x = 1)), list(x = 1))
-  expect_identical(as_list_unnamed_default(nlist(x = matrix(1:4))), list(x = matrix(1:4)))
-  expect_identical(as_list_unnamed_default(nlist(x = 1, a = 3)), list(x = 1, a = 3))
+  expect_identical(
+    as_list_unnamed_default(nlist(x = matrix(1:4))),
+    list(x = matrix(1:4))
+  )
+  expect_identical(
+    as_list_unnamed_default(nlist(x = 1, a = 3)),
+    list(x = 1, a = 3)
+  )
 })
 
 test_that("as_list.nlists", {
   expect_identical(as_list_unnamed_nlists(nlists(nlist())), list())
   expect_identical(as_list_unnamed_nlists(nlists(nlist(x = 1))), list(x = 1))
-  expect_identical(as_list_unnamed_nlists(nlists(nlist(x = matrix(1:4)))), list(x = matrix(1:4)))
-  expect_identical(as_list_unnamed_nlists(nlists(nlist(x = 1, a = 3))), list(x = 1, a = 3))
-  expect_identical(as_list_unnamed_nlists(nlists(nlist(x = 1), nlist(x = 3))), list(x = 1, x = 3))
-  expect_identical(as_list_unnamed_nlists(nlists(nlist(x = 1L), nlist(x = 3L))), list(x = 1L, x = 3L))
+  expect_identical(
+    as_list_unnamed_nlists(nlists(nlist(x = matrix(1:4)))),
+    list(x = matrix(1:4))
+  )
+  expect_identical(
+    as_list_unnamed_nlists(nlists(nlist(x = 1, a = 3))),
+    list(x = 1, a = 3)
+  )
+  expect_identical(
+    as_list_unnamed_nlists(nlists(nlist(x = 1), nlist(x = 3))),
+    list(x = 1, x = 3)
+  )
+  expect_identical(
+    as_list_unnamed_nlists(nlists(nlist(x = 1L), nlist(x = 3L))),
+    list(x = 1L, x = 3L)
+  )
 })

--- a/tests/testthat/test-as-mcmc-list.R
+++ b/tests/testthat/test-as-mcmc-list.R
@@ -1,85 +1,200 @@
 test_that("as_mcmc_list.nlist", {
   expect_identical(
     as_mcmc_list(nlist()),
-    structure(list(structure(numeric(0), mcpar = c(1, 0, 1), class = "mcmc")), class = "mcmc.list")
+    structure(
+      list(structure(numeric(0), mcpar = c(1, 0, 1), class = "mcmc")),
+      class = "mcmc.list"
+    )
   )
   expect_identical(
     as_mcmc_list(nlist(x = 1)),
-    structure(list(structure(1, .Dim = c(1L, 1L), .Dimnames = list(
-      NULL, "x"
-    ), mcpar = c(1, 1, 1), class = "mcmc")), class = "mcmc.list")
+    structure(
+      list(structure(
+        1,
+        .Dim = c(1L, 1L),
+        .Dimnames = list(
+          NULL,
+          "x"
+        ),
+        mcpar = c(1, 1, 1),
+        class = "mcmc"
+      )),
+      class = "mcmc.list"
+    )
   )
   expect_identical(
     as_mcmc_list(nlist(x = matrix(1:6, 2))),
-    structure(list(structure(1:6, .Dim = c(1L, 6L), .Dimnames = list(
-      NULL, c(
-        "x[1,1]", "x[2,1]", "x[1,2]", "x[2,2]", "x[1,3]",
-        "x[2,3]"
-      )
-    ), mcpar = c(1, 1, 1), class = "mcmc")), class = "mcmc.list")
+    structure(
+      list(structure(
+        1:6,
+        .Dim = c(1L, 6L),
+        .Dimnames = list(
+          NULL,
+          c(
+            "x[1,1]",
+            "x[2,1]",
+            "x[1,2]",
+            "x[2,2]",
+            "x[1,3]",
+            "x[2,3]"
+          )
+        ),
+        mcpar = c(1, 1, 1),
+        class = "mcmc"
+      )),
+      class = "mcmc.list"
+    )
   )
   expect_identical(
     as_mcmc_list(nlist(x = 1:2, y = 3)),
-    structure(list(structure(c(1, 2, 3), .Dim = c(1L, 3L), .Dimnames = list(
-      NULL, c("x[1]", "x[2]", "y")
-    ), mcpar = c(1, 1, 1), class = "mcmc")), class = "mcmc.list")
+    structure(
+      list(structure(
+        c(1, 2, 3),
+        .Dim = c(1L, 3L),
+        .Dimnames = list(
+          NULL,
+          c("x[1]", "x[2]", "y")
+        ),
+        mcpar = c(1, 1, 1),
+        class = "mcmc"
+      )),
+      class = "mcmc.list"
+    )
   )
   expect_identical(
     as_mcmc_list(nlist(x = NA_real_, y = 1)),
-    structure(list(structure(c(NA, 1), .Dim = 1:2, .Dimnames = list(
-      NULL, c("x", "y")
-    ), mcpar = c(1, 1, 1), class = "mcmc")), class = "mcmc.list")
+    structure(
+      list(structure(
+        c(NA, 1),
+        .Dim = 1:2,
+        .Dimnames = list(
+          NULL,
+          c("x", "y")
+        ),
+        mcpar = c(1, 1, 1),
+        class = "mcmc"
+      )),
+      class = "mcmc.list"
+    )
   )
 
   expect_identical(
     as_mcmc_list(nlist::nlist(x = 1, y = matrix(1:4, 2))),
-    structure(list(structure(c(1, 1, 2, 3, 4), .Dim = c(1L, 5L), .Dimnames = list(
-      NULL, c("x", "y[1,1]", "y[2,1]", "y[1,2]", "y[2,2]")
-    ), mcpar = c(
-      1,
-      1, 1
-    ), class = "mcmc")), class = "mcmc.list")
+    structure(
+      list(structure(
+        c(1, 1, 2, 3, 4),
+        .Dim = c(1L, 5L),
+        .Dimnames = list(
+          NULL,
+          c("x", "y[1,1]", "y[2,1]", "y[1,2]", "y[2,2]")
+        ),
+        mcpar = c(
+          1,
+          1,
+          1
+        ),
+        class = "mcmc"
+      )),
+      class = "mcmc.list"
+    )
   )
 })
 
 test_that("as_mcmc_list.nlists", {
   expect_identical(
     as_mcmc_list(nlists()),
-    structure(list(structure(numeric(0), mcpar = c(1, 0, 1), class = "mcmc")), class = "mcmc.list")
+    structure(
+      list(structure(numeric(0), mcpar = c(1, 0, 1), class = "mcmc")),
+      class = "mcmc.list"
+    )
   )
   expect_identical(
     as_mcmc_list(nlists(nlist())),
-    structure(list(structure(numeric(0), .Dim = 1:0, .Dimnames = list(
-      NULL, NULL
-    ), mcpar = c(1, 1, 1), class = "mcmc")), class = "mcmc.list")
+    structure(
+      list(structure(
+        numeric(0),
+        .Dim = 1:0,
+        .Dimnames = list(
+          NULL,
+          NULL
+        ),
+        mcpar = c(1, 1, 1),
+        class = "mcmc"
+      )),
+      class = "mcmc.list"
+    )
   )
   expect_identical(
     as_mcmc_list(nlists(nlist(), nlist())),
-    structure(list(structure(numeric(0), .Dim = c(2L, 0L), .Dimnames = list(
-      NULL, NULL
-    ), mcpar = c(1, 2, 1), class = "mcmc")), class = "mcmc.list")
+    structure(
+      list(structure(
+        numeric(0),
+        .Dim = c(2L, 0L),
+        .Dimnames = list(
+          NULL,
+          NULL
+        ),
+        mcpar = c(1, 2, 1),
+        class = "mcmc"
+      )),
+      class = "mcmc.list"
+    )
   )
 
   expect_identical(
     as_mcmc_list(nlists(nlist(x = 1))),
-    structure(list(structure(1, .Dim = c(1L, 1L), .Dimnames = list(
-      NULL, "x"
-    ), mcpar = c(1, 1, 1), class = "mcmc")), class = "mcmc.list")
+    structure(
+      list(structure(
+        1,
+        .Dim = c(1L, 1L),
+        .Dimnames = list(
+          NULL,
+          "x"
+        ),
+        mcpar = c(1, 1, 1),
+        class = "mcmc"
+      )),
+      class = "mcmc.list"
+    )
   )
   expect_identical(
     as_mcmc_list(nlists(nlist(x = 1), nlist(x = 3))),
-    structure(list(structure(c(1, 3), .Dim = 2:1, .Dimnames = list(
-      NULL, "x"
-    ), mcpar = c(1, 2, 1), class = "mcmc")), class = "mcmc.list")
+    structure(
+      list(structure(
+        c(1, 3),
+        .Dim = 2:1,
+        .Dimnames = list(
+          NULL,
+          "x"
+        ),
+        mcpar = c(1, 2, 1),
+        class = "mcmc"
+      )),
+      class = "mcmc.list"
+    )
   )
   expect_identical(
     as_mcmc_list(nlists(nlist(x = matrix(1:6, 2)))),
-    structure(list(structure(1:6, .Dim = c(1L, 6L), .Dimnames = list(
-      NULL, c(
-        "x[1,1]", "x[2,1]", "x[1,2]", "x[2,2]", "x[1,3]",
-        "x[2,3]"
-      )
-    ), mcpar = c(1, 1, 1), class = "mcmc")), class = "mcmc.list")
+    structure(
+      list(structure(
+        1:6,
+        .Dim = c(1L, 6L),
+        .Dimnames = list(
+          NULL,
+          c(
+            "x[1,1]",
+            "x[2,1]",
+            "x[1,2]",
+            "x[2,2]",
+            "x[1,3]",
+            "x[2,3]"
+          )
+        ),
+        mcpar = c(1, 1, 1),
+        class = "mcmc"
+      )),
+      class = "mcmc.list"
+    )
   )
 
   expect_identical(
@@ -87,119 +202,291 @@ test_that("as_mcmc_list.nlists", {
       nlist(x = matrix(1:6, 2)),
       nlist(x = matrix(3:8, 2))
     )),
-    structure(list(structure(c(
-      1L, 3L, 2L, 4L, 3L, 5L, 4L, 6L, 5L,
-      7L, 6L, 8L
-    ), .Dim = c(2L, 6L), .Dimnames = list(NULL, c(
-      "x[1,1]",
-      "x[2,1]", "x[1,2]", "x[2,2]", "x[1,3]", "x[2,3]"
-    )), mcpar = c(
-      1,
-      2, 1
-    ), class = "mcmc")), class = "mcmc.list")
+    structure(
+      list(structure(
+        c(
+          1L,
+          3L,
+          2L,
+          4L,
+          3L,
+          5L,
+          4L,
+          6L,
+          5L,
+          7L,
+          6L,
+          8L
+        ),
+        .Dim = c(2L, 6L),
+        .Dimnames = list(
+          NULL,
+          c(
+            "x[1,1]",
+            "x[2,1]",
+            "x[1,2]",
+            "x[2,2]",
+            "x[1,3]",
+            "x[2,3]"
+          )
+        ),
+        mcpar = c(
+          1,
+          2,
+          1
+        ),
+        class = "mcmc"
+      )),
+      class = "mcmc.list"
+    )
   )
 
   nlists <- nlists(nlist(x = matrix(1:6, 2)), nlist(x = matrix(3:8, 2)))
   attr(nlists, "nchains") <- 2L
   expect_identical(
     as_mcmc_list(nlists),
-    structure(list(`1` = structure(1:6, .Dim = c(1L, 6L), .Dimnames = list(
-      NULL, c(
-        "x[1,1]", "x[2,1]", "x[1,2]", "x[2,2]", "x[1,3]",
-        "x[2,3]"
-      )
-    ), mcpar = c(1, 1, 1), class = "mcmc"), `2` = structure(3:8, .Dim = c(
-      1L,
-      6L
-    ), .Dimnames = list(NULL, c(
-      "x[1,1]", "x[2,1]", "x[1,2]", "x[2,2]",
-      "x[1,3]", "x[2,3]"
-    )), mcpar = c(1, 1, 1), class = "mcmc")), class = "mcmc.list")
+    structure(
+      list(
+        `1` = structure(
+          1:6,
+          .Dim = c(1L, 6L),
+          .Dimnames = list(
+            NULL,
+            c(
+              "x[1,1]",
+              "x[2,1]",
+              "x[1,2]",
+              "x[2,2]",
+              "x[1,3]",
+              "x[2,3]"
+            )
+          ),
+          mcpar = c(1, 1, 1),
+          class = "mcmc"
+        ),
+        `2` = structure(
+          3:8,
+          .Dim = c(
+            1L,
+            6L
+          ),
+          .Dimnames = list(
+            NULL,
+            c(
+              "x[1,1]",
+              "x[2,1]",
+              "x[1,2]",
+              "x[2,2]",
+              "x[1,3]",
+              "x[2,3]"
+            )
+          ),
+          mcpar = c(1, 1, 1),
+          class = "mcmc"
+        )
+      ),
+      class = "mcmc.list"
+    )
   )
 })
 
 test_that("as.mcmc.list.nlist", {
   expect_identical(
     coda::as.mcmc.list(nlist()),
-    structure(list(structure(numeric(0), mcpar = c(1, 0, 1), class = "mcmc")), class = "mcmc.list")
+    structure(
+      list(structure(numeric(0), mcpar = c(1, 0, 1), class = "mcmc")),
+      class = "mcmc.list"
+    )
   )
   expect_identical(
     coda::as.mcmc.list(nlist(x = 1)),
-    structure(list(structure(1, .Dim = c(1L, 1L), .Dimnames = list(
-      NULL, "x"
-    ), mcpar = c(1, 1, 1), class = "mcmc")), class = "mcmc.list")
+    structure(
+      list(structure(
+        1,
+        .Dim = c(1L, 1L),
+        .Dimnames = list(
+          NULL,
+          "x"
+        ),
+        mcpar = c(1, 1, 1),
+        class = "mcmc"
+      )),
+      class = "mcmc.list"
+    )
   )
   expect_identical(
     coda::as.mcmc.list(nlist(x = matrix(1:6, 2))),
-    structure(list(structure(1:6, .Dim = c(1L, 6L), .Dimnames = list(
-      NULL, c(
-        "x[1,1]", "x[2,1]", "x[1,2]", "x[2,2]", "x[1,3]",
-        "x[2,3]"
-      )
-    ), mcpar = c(1, 1, 1), class = "mcmc")), class = "mcmc.list")
+    structure(
+      list(structure(
+        1:6,
+        .Dim = c(1L, 6L),
+        .Dimnames = list(
+          NULL,
+          c(
+            "x[1,1]",
+            "x[2,1]",
+            "x[1,2]",
+            "x[2,2]",
+            "x[1,3]",
+            "x[2,3]"
+          )
+        ),
+        mcpar = c(1, 1, 1),
+        class = "mcmc"
+      )),
+      class = "mcmc.list"
+    )
   )
   expect_identical(
     coda::as.mcmc.list(nlist(x = 1:2, y = 3)),
-    structure(list(structure(c(1, 2, 3), .Dim = c(1L, 3L), .Dimnames = list(
-      NULL, c("x[1]", "x[2]", "y")
-    ), mcpar = c(1, 1, 1), class = "mcmc")), class = "mcmc.list")
+    structure(
+      list(structure(
+        c(1, 2, 3),
+        .Dim = c(1L, 3L),
+        .Dimnames = list(
+          NULL,
+          c("x[1]", "x[2]", "y")
+        ),
+        mcpar = c(1, 1, 1),
+        class = "mcmc"
+      )),
+      class = "mcmc.list"
+    )
   )
   expect_identical(
     coda::as.mcmc.list(nlist(x = NA_real_, y = 1)),
-    structure(list(structure(c(NA, 1), .Dim = 1:2, .Dimnames = list(
-      NULL, c("x", "y")
-    ), mcpar = c(1, 1, 1), class = "mcmc")), class = "mcmc.list")
+    structure(
+      list(structure(
+        c(NA, 1),
+        .Dim = 1:2,
+        .Dimnames = list(
+          NULL,
+          c("x", "y")
+        ),
+        mcpar = c(1, 1, 1),
+        class = "mcmc"
+      )),
+      class = "mcmc.list"
+    )
   )
 
   expect_identical(
     coda::as.mcmc.list(nlist::nlist(x = 1, y = matrix(1:4, 2))),
-    structure(list(structure(c(1, 1, 2, 3, 4), .Dim = c(1L, 5L), .Dimnames = list(
-      NULL, c("x", "y[1,1]", "y[2,1]", "y[1,2]", "y[2,2]")
-    ), mcpar = c(
-      1,
-      1, 1
-    ), class = "mcmc")), class = "mcmc.list")
+    structure(
+      list(structure(
+        c(1, 1, 2, 3, 4),
+        .Dim = c(1L, 5L),
+        .Dimnames = list(
+          NULL,
+          c("x", "y[1,1]", "y[2,1]", "y[1,2]", "y[2,2]")
+        ),
+        mcpar = c(
+          1,
+          1,
+          1
+        ),
+        class = "mcmc"
+      )),
+      class = "mcmc.list"
+    )
   )
 })
 
 test_that("as.mcmc.list.nlists", {
   expect_identical(
     coda::as.mcmc.list(nlists()),
-    structure(list(structure(numeric(0), mcpar = c(1, 0, 1), class = "mcmc")), class = "mcmc.list")
+    structure(
+      list(structure(numeric(0), mcpar = c(1, 0, 1), class = "mcmc")),
+      class = "mcmc.list"
+    )
   )
   expect_identical(
     coda::as.mcmc.list(nlists(nlist())),
-    structure(list(structure(numeric(0), .Dim = 1:0, .Dimnames = list(
-      NULL, NULL
-    ), mcpar = c(1, 1, 1), class = "mcmc")), class = "mcmc.list")
+    structure(
+      list(structure(
+        numeric(0),
+        .Dim = 1:0,
+        .Dimnames = list(
+          NULL,
+          NULL
+        ),
+        mcpar = c(1, 1, 1),
+        class = "mcmc"
+      )),
+      class = "mcmc.list"
+    )
   )
   expect_identical(
     coda::as.mcmc.list(nlists(nlist(), nlist())),
-    structure(list(structure(numeric(0), .Dim = c(2L, 0L), .Dimnames = list(
-      NULL, NULL
-    ), mcpar = c(1, 2, 1), class = "mcmc")), class = "mcmc.list")
+    structure(
+      list(structure(
+        numeric(0),
+        .Dim = c(2L, 0L),
+        .Dimnames = list(
+          NULL,
+          NULL
+        ),
+        mcpar = c(1, 2, 1),
+        class = "mcmc"
+      )),
+      class = "mcmc.list"
+    )
   )
 
   expect_identical(
     coda::as.mcmc.list(nlists(nlist(x = 1))),
-    structure(list(structure(1, .Dim = c(1L, 1L), .Dimnames = list(
-      NULL, "x"
-    ), mcpar = c(1, 1, 1), class = "mcmc")), class = "mcmc.list")
+    structure(
+      list(structure(
+        1,
+        .Dim = c(1L, 1L),
+        .Dimnames = list(
+          NULL,
+          "x"
+        ),
+        mcpar = c(1, 1, 1),
+        class = "mcmc"
+      )),
+      class = "mcmc.list"
+    )
   )
   expect_identical(
     coda::as.mcmc.list(nlists(nlist(x = 1), nlist(x = 3))),
-    structure(list(structure(c(1, 3), .Dim = 2:1, .Dimnames = list(
-      NULL, "x"
-    ), mcpar = c(1, 2, 1), class = "mcmc")), class = "mcmc.list")
+    structure(
+      list(structure(
+        c(1, 3),
+        .Dim = 2:1,
+        .Dimnames = list(
+          NULL,
+          "x"
+        ),
+        mcpar = c(1, 2, 1),
+        class = "mcmc"
+      )),
+      class = "mcmc.list"
+    )
   )
   expect_identical(
     coda::as.mcmc.list(nlists(nlist(x = matrix(1:6, 2)))),
-    structure(list(structure(1:6, .Dim = c(1L, 6L), .Dimnames = list(
-      NULL, c(
-        "x[1,1]", "x[2,1]", "x[1,2]", "x[2,2]", "x[1,3]",
-        "x[2,3]"
-      )
-    ), mcpar = c(1, 1, 1), class = "mcmc")), class = "mcmc.list")
+    structure(
+      list(structure(
+        1:6,
+        .Dim = c(1L, 6L),
+        .Dimnames = list(
+          NULL,
+          c(
+            "x[1,1]",
+            "x[2,1]",
+            "x[1,2]",
+            "x[2,2]",
+            "x[1,3]",
+            "x[2,3]"
+          )
+        ),
+        mcpar = c(1, 1, 1),
+        class = "mcmc"
+      )),
+      class = "mcmc.list"
+    )
   )
 
   expect_identical(
@@ -207,33 +494,90 @@ test_that("as.mcmc.list.nlists", {
       nlist(x = matrix(1:6, 2)),
       nlist(x = matrix(3:8, 2))
     )),
-    structure(list(structure(c(
-      1L, 3L, 2L, 4L, 3L, 5L, 4L, 6L, 5L,
-      7L, 6L, 8L
-    ), .Dim = c(2L, 6L), .Dimnames = list(NULL, c(
-      "x[1,1]",
-      "x[2,1]", "x[1,2]", "x[2,2]", "x[1,3]", "x[2,3]"
-    )), mcpar = c(
-      1,
-      2, 1
-    ), class = "mcmc")), class = "mcmc.list")
+    structure(
+      list(structure(
+        c(
+          1L,
+          3L,
+          2L,
+          4L,
+          3L,
+          5L,
+          4L,
+          6L,
+          5L,
+          7L,
+          6L,
+          8L
+        ),
+        .Dim = c(2L, 6L),
+        .Dimnames = list(
+          NULL,
+          c(
+            "x[1,1]",
+            "x[2,1]",
+            "x[1,2]",
+            "x[2,2]",
+            "x[1,3]",
+            "x[2,3]"
+          )
+        ),
+        mcpar = c(
+          1,
+          2,
+          1
+        ),
+        class = "mcmc"
+      )),
+      class = "mcmc.list"
+    )
   )
 
   nlists <- nlists(nlist(x = matrix(1:6, 2)), nlist(x = matrix(3:8, 2)))
   attr(nlists, "nchains") <- 2L
   expect_identical(
     coda::as.mcmc.list(nlists),
-    structure(list(`1` = structure(1:6, .Dim = c(1L, 6L), .Dimnames = list(
-      NULL, c(
-        "x[1,1]", "x[2,1]", "x[1,2]", "x[2,2]", "x[1,3]",
-        "x[2,3]"
-      )
-    ), mcpar = c(1, 1, 1), class = "mcmc"), `2` = structure(3:8, .Dim = c(
-      1L,
-      6L
-    ), .Dimnames = list(NULL, c(
-      "x[1,1]", "x[2,1]", "x[1,2]", "x[2,2]",
-      "x[1,3]", "x[2,3]"
-    )), mcpar = c(1, 1, 1), class = "mcmc")), class = "mcmc.list")
+    structure(
+      list(
+        `1` = structure(
+          1:6,
+          .Dim = c(1L, 6L),
+          .Dimnames = list(
+            NULL,
+            c(
+              "x[1,1]",
+              "x[2,1]",
+              "x[1,2]",
+              "x[2,2]",
+              "x[1,3]",
+              "x[2,3]"
+            )
+          ),
+          mcpar = c(1, 1, 1),
+          class = "mcmc"
+        ),
+        `2` = structure(
+          3:8,
+          .Dim = c(
+            1L,
+            6L
+          ),
+          .Dimnames = list(
+            NULL,
+            c(
+              "x[1,1]",
+              "x[2,1]",
+              "x[1,2]",
+              "x[2,2]",
+              "x[1,3]",
+              "x[2,3]"
+            )
+          ),
+          mcpar = c(1, 1, 1),
+          class = "mcmc"
+        )
+      ),
+      class = "mcmc.list"
+    )
   )
 })

--- a/tests/testthat/test-as-mcmc.R
+++ b/tests/testthat/test-as-mcmc.R
@@ -12,44 +12,88 @@ test_that("as_mcmc.nlist", {
   )
   expect_identical(
     as_mcmc(nlist(x = 1)),
-    structure(1, .Dim = c(1L, 1L), .Dimnames = list(NULL, "x"), mcpar = c(
+    structure(
       1,
-      1, 1
-    ), class = "mcmc")
+      .Dim = c(1L, 1L),
+      .Dimnames = list(NULL, "x"),
+      mcpar = c(
+        1,
+        1,
+        1
+      ),
+      class = "mcmc"
+    )
   )
   expect_identical(
     as_mcmc(nlist(x = matrix(1:6, 2))),
-    structure(1:6, .Dim = c(1L, 6L), .Dimnames = list(NULL, c(
-      "x[1,1]",
-      "x[2,1]", "x[1,2]", "x[2,2]", "x[1,3]", "x[2,3]"
-    )), mcpar = c(
-      1,
-      1, 1
-    ), class = "mcmc")
+    structure(
+      1:6,
+      .Dim = c(1L, 6L),
+      .Dimnames = list(
+        NULL,
+        c(
+          "x[1,1]",
+          "x[2,1]",
+          "x[1,2]",
+          "x[2,2]",
+          "x[1,3]",
+          "x[2,3]"
+        )
+      ),
+      mcpar = c(
+        1,
+        1,
+        1
+      ),
+      class = "mcmc"
+    )
   )
   expect_identical(
     as_mcmc(nlist(x = 1:2, y = 3)),
-    structure(c(1, 2, 3), .Dim = c(1L, 3L), .Dimnames = list(
-      NULL,
-      c("x[1]", "x[2]", "y")
-    ), mcpar = c(1, 1, 1), class = "mcmc")
+    structure(
+      c(1, 2, 3),
+      .Dim = c(1L, 3L),
+      .Dimnames = list(
+        NULL,
+        c("x[1]", "x[2]", "y")
+      ),
+      mcpar = c(1, 1, 1),
+      class = "mcmc"
+    )
   )
   expect_identical(
     as_mcmc(nlist(x = NA_real_, y = 1)),
-    structure(c(NA, 1), .Dim = 1:2, .Dimnames = list(NULL, c(
-      "x",
-      "y"
-    )), mcpar = c(1, 1, 1), class = "mcmc")
+    structure(
+      c(NA, 1),
+      .Dim = 1:2,
+      .Dimnames = list(
+        NULL,
+        c(
+          "x",
+          "y"
+        )
+      ),
+      mcpar = c(1, 1, 1),
+      class = "mcmc"
+    )
   )
 
   expect_identical(
     as_mcmc(nlist::nlist(x = 1, y = matrix(1:4, 2))),
-    structure(c(1, 1, 2, 3, 4), .Dim = c(1L, 5L), .Dimnames = list(
-      NULL, c("x", "y[1,1]", "y[2,1]", "y[1,2]", "y[2,2]")
-    ), mcpar = c(
-      1,
-      1, 1
-    ), class = "mcmc")
+    structure(
+      c(1, 1, 2, 3, 4),
+      .Dim = c(1L, 5L),
+      .Dimnames = list(
+        NULL,
+        c("x", "y[1,1]", "y[2,1]", "y[1,2]", "y[2,2]")
+      ),
+      mcpar = c(
+        1,
+        1,
+        1
+      ),
+      class = "mcmc"
+    )
   )
 })
 
@@ -60,42 +104,83 @@ test_that("as_mcmc.nlists", {
   )
   expect_identical(
     as_mcmc(nlists(nlist())),
-    structure(numeric(0), .Dim = 1:0, .Dimnames = list(NULL, NULL), mcpar = c(
-      1,
-      1, 1
-    ), class = "mcmc")
+    structure(
+      numeric(0),
+      .Dim = 1:0,
+      .Dimnames = list(NULL, NULL),
+      mcpar = c(
+        1,
+        1,
+        1
+      ),
+      class = "mcmc"
+    )
   )
   expect_identical(
     as_mcmc(nlists(nlist(), nlist())),
-    structure(numeric(0), .Dim = c(2L, 0L), .Dimnames = list(
-      NULL,
-      NULL
-    ), mcpar = c(1, 2, 1), class = "mcmc")
+    structure(
+      numeric(0),
+      .Dim = c(2L, 0L),
+      .Dimnames = list(
+        NULL,
+        NULL
+      ),
+      mcpar = c(1, 2, 1),
+      class = "mcmc"
+    )
   )
 
   expect_identical(
     as_mcmc(nlists(nlist(x = 1))),
-    structure(1, .Dim = c(1L, 1L), .Dimnames = list(NULL, "x"), mcpar = c(
+    structure(
       1,
-      1, 1
-    ), class = "mcmc")
+      .Dim = c(1L, 1L),
+      .Dimnames = list(NULL, "x"),
+      mcpar = c(
+        1,
+        1,
+        1
+      ),
+      class = "mcmc"
+    )
   )
   expect_identical(
     as_mcmc(nlists(nlist(x = 1), nlist(x = 3))),
-    structure(c(1, 3), .Dim = 2:1, .Dimnames = list(NULL, "x"), mcpar = c(
-      1,
-      2, 1
-    ), class = "mcmc")
+    structure(
+      c(1, 3),
+      .Dim = 2:1,
+      .Dimnames = list(NULL, "x"),
+      mcpar = c(
+        1,
+        2,
+        1
+      ),
+      class = "mcmc"
+    )
   )
   expect_identical(
     as_mcmc(nlists(nlist(x = matrix(1:6, 2)))),
-    structure(1:6, .Dim = c(1L, 6L), .Dimnames = list(NULL, c(
-      "x[1,1]",
-      "x[2,1]", "x[1,2]", "x[2,2]", "x[1,3]", "x[2,3]"
-    )), mcpar = c(
-      1,
-      1, 1
-    ), class = "mcmc")
+    structure(
+      1:6,
+      .Dim = c(1L, 6L),
+      .Dimnames = list(
+        NULL,
+        c(
+          "x[1,1]",
+          "x[2,1]",
+          "x[1,2]",
+          "x[2,2]",
+          "x[1,3]",
+          "x[2,3]"
+        )
+      ),
+      mcpar = c(
+        1,
+        1,
+        1
+      ),
+      class = "mcmc"
+    )
   )
 
   expect_identical(
@@ -103,13 +188,26 @@ test_that("as_mcmc.nlists", {
       nlist(x = matrix(1:6, 2)),
       nlist(x = matrix(3:8, 2))
     )),
-    structure(c(1L, 3L, 2L, 4L, 3L, 5L, 4L, 6L, 5L, 7L, 6L, 8L), .Dim = c(
-      2L,
-      6L
-    ), .Dimnames = list(NULL, c(
-      "x[1,1]", "x[2,1]", "x[1,2]", "x[2,2]",
-      "x[1,3]", "x[2,3]"
-    )), mcpar = c(1, 2, 1), class = "mcmc")
+    structure(
+      c(1L, 3L, 2L, 4L, 3L, 5L, 4L, 6L, 5L, 7L, 6L, 8L),
+      .Dim = c(
+        2L,
+        6L
+      ),
+      .Dimnames = list(
+        NULL,
+        c(
+          "x[1,1]",
+          "x[2,1]",
+          "x[1,2]",
+          "x[2,2]",
+          "x[1,3]",
+          "x[2,3]"
+        )
+      ),
+      mcpar = c(1, 2, 1),
+      class = "mcmc"
+    )
   )
 })
 
@@ -120,44 +218,88 @@ test_that("as.mcmc.nlist", {
   )
   expect_identical(
     as.mcmc(nlist(x = 1)),
-    structure(1, .Dim = c(1L, 1L), .Dimnames = list(NULL, "x"), mcpar = c(
+    structure(
       1,
-      1, 1
-    ), class = "mcmc")
+      .Dim = c(1L, 1L),
+      .Dimnames = list(NULL, "x"),
+      mcpar = c(
+        1,
+        1,
+        1
+      ),
+      class = "mcmc"
+    )
   )
   expect_identical(
     as.mcmc(nlist(x = matrix(1:6, 2))),
-    structure(1:6, .Dim = c(1L, 6L), .Dimnames = list(NULL, c(
-      "x[1,1]",
-      "x[2,1]", "x[1,2]", "x[2,2]", "x[1,3]", "x[2,3]"
-    )), mcpar = c(
-      1,
-      1, 1
-    ), class = "mcmc")
+    structure(
+      1:6,
+      .Dim = c(1L, 6L),
+      .Dimnames = list(
+        NULL,
+        c(
+          "x[1,1]",
+          "x[2,1]",
+          "x[1,2]",
+          "x[2,2]",
+          "x[1,3]",
+          "x[2,3]"
+        )
+      ),
+      mcpar = c(
+        1,
+        1,
+        1
+      ),
+      class = "mcmc"
+    )
   )
   expect_identical(
     as.mcmc(nlist(x = 1:2, y = 3)),
-    structure(c(1, 2, 3), .Dim = c(1L, 3L), .Dimnames = list(
-      NULL,
-      c("x[1]", "x[2]", "y")
-    ), mcpar = c(1, 1, 1), class = "mcmc")
+    structure(
+      c(1, 2, 3),
+      .Dim = c(1L, 3L),
+      .Dimnames = list(
+        NULL,
+        c("x[1]", "x[2]", "y")
+      ),
+      mcpar = c(1, 1, 1),
+      class = "mcmc"
+    )
   )
   expect_identical(
     as.mcmc(nlist(x = NA_real_, y = 1)),
-    structure(c(NA, 1), .Dim = 1:2, .Dimnames = list(NULL, c(
-      "x",
-      "y"
-    )), mcpar = c(1, 1, 1), class = "mcmc")
+    structure(
+      c(NA, 1),
+      .Dim = 1:2,
+      .Dimnames = list(
+        NULL,
+        c(
+          "x",
+          "y"
+        )
+      ),
+      mcpar = c(1, 1, 1),
+      class = "mcmc"
+    )
   )
 
   expect_identical(
     as.mcmc(nlist::nlist(x = 1, y = matrix(1:4, 2))),
-    structure(c(1, 1, 2, 3, 4), .Dim = c(1L, 5L), .Dimnames = list(
-      NULL, c("x", "y[1,1]", "y[2,1]", "y[1,2]", "y[2,2]")
-    ), mcpar = c(
-      1,
-      1, 1
-    ), class = "mcmc")
+    structure(
+      c(1, 1, 2, 3, 4),
+      .Dim = c(1L, 5L),
+      .Dimnames = list(
+        NULL,
+        c("x", "y[1,1]", "y[2,1]", "y[1,2]", "y[2,2]")
+      ),
+      mcpar = c(
+        1,
+        1,
+        1
+      ),
+      class = "mcmc"
+    )
   )
 })
 
@@ -168,42 +310,83 @@ test_that("as.mcmc.nlists", {
   )
   expect_identical(
     as.mcmc(nlists(nlist())),
-    structure(numeric(0), .Dim = 1:0, .Dimnames = list(NULL, NULL), mcpar = c(
-      1,
-      1, 1
-    ), class = "mcmc")
+    structure(
+      numeric(0),
+      .Dim = 1:0,
+      .Dimnames = list(NULL, NULL),
+      mcpar = c(
+        1,
+        1,
+        1
+      ),
+      class = "mcmc"
+    )
   )
   expect_identical(
     as.mcmc(nlists(nlist(), nlist())),
-    structure(numeric(0), .Dim = c(2L, 0L), .Dimnames = list(
-      NULL,
-      NULL
-    ), mcpar = c(1, 2, 1), class = "mcmc")
+    structure(
+      numeric(0),
+      .Dim = c(2L, 0L),
+      .Dimnames = list(
+        NULL,
+        NULL
+      ),
+      mcpar = c(1, 2, 1),
+      class = "mcmc"
+    )
   )
 
   expect_identical(
     as.mcmc(nlists(nlist(x = 1))),
-    structure(1, .Dim = c(1L, 1L), .Dimnames = list(NULL, "x"), mcpar = c(
+    structure(
       1,
-      1, 1
-    ), class = "mcmc")
+      .Dim = c(1L, 1L),
+      .Dimnames = list(NULL, "x"),
+      mcpar = c(
+        1,
+        1,
+        1
+      ),
+      class = "mcmc"
+    )
   )
   expect_identical(
     as.mcmc(nlists(nlist(x = 1), nlist(x = 3))),
-    structure(c(1, 3), .Dim = 2:1, .Dimnames = list(NULL, "x"), mcpar = c(
-      1,
-      2, 1
-    ), class = "mcmc")
+    structure(
+      c(1, 3),
+      .Dim = 2:1,
+      .Dimnames = list(NULL, "x"),
+      mcpar = c(
+        1,
+        2,
+        1
+      ),
+      class = "mcmc"
+    )
   )
   expect_identical(
     as.mcmc(nlists(nlist(x = matrix(1:6, 2)))),
-    structure(1:6, .Dim = c(1L, 6L), .Dimnames = list(NULL, c(
-      "x[1,1]",
-      "x[2,1]", "x[1,2]", "x[2,2]", "x[1,3]", "x[2,3]"
-    )), mcpar = c(
-      1,
-      1, 1
-    ), class = "mcmc")
+    structure(
+      1:6,
+      .Dim = c(1L, 6L),
+      .Dimnames = list(
+        NULL,
+        c(
+          "x[1,1]",
+          "x[2,1]",
+          "x[1,2]",
+          "x[2,2]",
+          "x[1,3]",
+          "x[2,3]"
+        )
+      ),
+      mcpar = c(
+        1,
+        1,
+        1
+      ),
+      class = "mcmc"
+    )
   )
 
   expect_identical(
@@ -211,12 +394,25 @@ test_that("as.mcmc.nlists", {
       nlist(x = matrix(1:6, 2)),
       nlist(x = matrix(3:8, 2))
     )),
-    structure(c(1L, 3L, 2L, 4L, 3L, 5L, 4L, 6L, 5L, 7L, 6L, 8L), .Dim = c(
-      2L,
-      6L
-    ), .Dimnames = list(NULL, c(
-      "x[1,1]", "x[2,1]", "x[1,2]", "x[2,2]",
-      "x[1,3]", "x[2,3]"
-    )), mcpar = c(1, 2, 1), class = "mcmc")
+    structure(
+      c(1L, 3L, 2L, 4L, 3L, 5L, 4L, 6L, 5L, 7L, 6L, 8L),
+      .Dim = c(
+        2L,
+        6L
+      ),
+      .Dimnames = list(
+        NULL,
+        c(
+          "x[1,1]",
+          "x[2,1]",
+          "x[1,2]",
+          "x[2,2]",
+          "x[1,3]",
+          "x[2,3]"
+        )
+      ),
+      mcpar = c(1, 2, 1),
+      class = "mcmc"
+    )
   )
 })

--- a/tests/testthat/test-as-nlist.R
+++ b/tests/testthat/test-as-nlist.R
@@ -1,18 +1,38 @@
 test_that("as_nlist.numeric", {
   expect_s3_class(as_nlist(c(x = 1)), "nlist")
   expect_error(as_nlist(1), "^`x` must be named[.]$", class = "chk_error")
-  expect_error(as_nlist(c(x = 1, x = 2)), "^`names[(]x[)]` must be unique[.]$", class = "chk_error")
-  expect_error(as_nlist(c(`x[1]` = 1, `x[1,2]` = 2)), "^All elements of term vector `names[(]x[)]` must be consistent[.]$", class = "chk_error")
-  expect_identical(as_nlist(c(`a[2]` = 1, `a[1]` = 2)), structure(list(a = c(2, 1)), class = "nlist"))
-  expect_identical(as_nlist(c(`a[2]` = 3L, `a[1]` = 2L)), structure(list(a = c(2L, 3L)), class = "nlist"))
+  expect_error(
+    as_nlist(c(x = 1, x = 2)),
+    "^`names[(]x[)]` must be unique[.]$",
+    class = "chk_error"
+  )
+  expect_error(
+    as_nlist(c(`x[1]` = 1, `x[1,2]` = 2)),
+    "^All elements of term vector `names[(]x[)]` must be consistent[.]$",
+    class = "chk_error"
+  )
+  expect_identical(
+    as_nlist(c(`a[2]` = 1, `a[1]` = 2)),
+    structure(list(a = c(2, 1)), class = "nlist")
+  )
+  expect_identical(
+    as_nlist(c(`a[2]` = 3L, `a[1]` = 2L)),
+    structure(list(a = c(2L, 3L)), class = "nlist")
+  )
   y <- nlist(g = matrix(1:4, ncol = 2), z = 1:3)
   expect_equal(as_nlist(unlist_nlist(y)), y)
 })
 
 
 test_that("as_nlist.numeric incomplete", {
-  expect_identical(as_nlist(c(`a[3]` = 1, `a[1]` = 2)), structure(list(a = c(2, NA, 1)), class = "nlist"))
-  expect_identical(as_nlist(c(`a[3]` = 1L, `a[1]` = 2L)), structure(list(a = c(2L, NA, 1L)), class = "nlist"))
+  expect_identical(
+    as_nlist(c(`a[3]` = 1, `a[1]` = 2)),
+    structure(list(a = c(2, NA, 1)), class = "nlist")
+  )
+  expect_identical(
+    as_nlist(c(`a[3]` = 1L, `a[1]` = 2L)),
+    structure(list(a = c(2L, NA, 1L)), class = "nlist")
+  )
 })
 
 test_that("as_nlist.list", {
@@ -25,20 +45,30 @@ test_that("as_nlist.mcmc", {
   #  expect_identical(as_nlist(as_mcmc(nlist(x = numeric(0)))), nlist())
   expect_identical(as_nlist(as_mcmc(nlist(x = 1))), nlist(x = 1))
   expect_identical(as_nlist(as_mcmc(nlist(x = 1, y = 2))), nlist(x = 1, y = 2))
-  expect_identical(as_nlist(as_mcmc(nlist(x = matrix(1:12, nrow = 3)))), nlist(x = matrix(1:12, nrow = 3)))
+  expect_identical(
+    as_nlist(as_mcmc(nlist(x = matrix(1:12, nrow = 3)))),
+    nlist(x = matrix(1:12, nrow = 3))
+  )
 })
 
 test_that("as_nlist.mcmc.list", {
   #  expect_identical(as_nlist(as_mcmc(nlist())), nlist())
   #  expect_identical(as_nlist(as_mcmc(nlist(x = numeric(0)))), nlist())
   expect_identical(as_nlist(as_mcmc_list(nlist(x = 1))), nlist(x = 1))
-  expect_identical(as_nlist(as_mcmc_list(nlist(x = 1, y = 2))), nlist(x = 1, y = 2))
-  expect_identical(as_nlist(as_mcmc_list(nlist(x = matrix(1:12, nrow = 3)))), nlist(x = matrix(1:12, nrow = 3)))
+  expect_identical(
+    as_nlist(as_mcmc_list(nlist(x = 1, y = 2))),
+    nlist(x = 1, y = 2)
+  )
+  expect_identical(
+    as_nlist(as_mcmc_list(nlist(x = matrix(1:12, nrow = 3)))),
+    nlist(x = matrix(1:12, nrow = 3))
+  )
   expect_identical(
     as_nlist(as_mcmc_list(nlists(nlist(x = matrix(1:12, nrow = 3))))),
     nlist(x = matrix(1:12, nrow = 3))
   )
-  expect_error(as_nlist(as_mcmc_list(nlists(nlist(x = 1), nlist(x = 2)))),
+  expect_error(
+    as_nlist(as_mcmc_list(nlists(nlist(x = 1), nlist(x = 2)))),
     "`x` must have one iteration.",
     class = "chk_error"
   )
@@ -58,10 +88,16 @@ test_that("as_nlist.data.frame", {
       dte = as.Date(c("2001-01-02", "2001-01-01")),
       fac = factor(c("b", "a"))
     )),
-    structure(list(
-      lgl = c(1L, NA), int = 1:2, dbl = c(2.5, 1.5),
-      dte = c(11324, 11323), fac = 2:1
-    ), class = "nlist")
+    structure(
+      list(
+        lgl = c(1L, NA),
+        int = 1:2,
+        dbl = c(2.5, 1.5),
+        dte = c(11324, 11323),
+        fac = 2:1
+      ),
+      class = "nlist"
+    )
   )
 })
 

--- a/tests/testthat/test-as-nlists.R
+++ b/tests/testthat/test-as-nlists.R
@@ -57,7 +57,10 @@ test_that("as_nlists.nlists", {
 test_that("as_nlists.nlist", {
   expect_identical(
     as_nlists(nlist()),
-    structure(list(structure(list(), .Names = character(0), class = "nlist")), class = "nlists")
+    structure(
+      list(structure(list(), .Names = character(0), class = "nlist")),
+      class = "nlists"
+    )
   )
   expect_identical(
     as_nlists(nlist(x = 1)),

--- a/tests/testthat/test-as-term-frame.R
+++ b/tests/testthat/test-as-term-frame.R
@@ -3,48 +3,163 @@ test_that("as_term_frame.nlist", {
     as_term_frame(nlist()),
     data.frame(term = term::term(0), value = numeric(0))
   )
-  expect_identical(as_term_frame(nlist(x = 2:4)), structure(list(term = structure(c("x[1]", "x[2]", "x[3]"), class = c(
-    "term",
-    "vctrs_vctr"
-  )), value = c(2, 3, 4)), row.names = c(NA, -3L), class = "data.frame"))
-  expect_identical(as_term_frame(nlist(x = 1, y = 1:2)), structure(list(term = structure(c("x", "y[1]", "y[2]"), class = c(
-    "term",
-    "vctrs_vctr"
-  )), value = c(1, 1, 2)), row.names = c(NA, -3L), class = "data.frame"))
+  expect_identical(
+    as_term_frame(nlist(x = 2:4)),
+    structure(
+      list(
+        term = structure(
+          c("x[1]", "x[2]", "x[3]"),
+          class = c(
+            "term",
+            "vctrs_vctr"
+          )
+        ),
+        value = c(2, 3, 4)
+      ),
+      row.names = c(NA, -3L),
+      class = "data.frame"
+    )
+  )
+  expect_identical(
+    as_term_frame(nlist(x = 1, y = 1:2)),
+    structure(
+      list(
+        term = structure(
+          c("x", "y[1]", "y[2]"),
+          class = c(
+            "term",
+            "vctrs_vctr"
+          )
+        ),
+        value = c(1, 1, 2)
+      ),
+      row.names = c(NA, -3L),
+      class = "data.frame"
+    )
+  )
 })
 
 test_that("as_term_frame.nlists", {
-  expect_identical(as_term_frame(nlists()), structure(list(term = structure(character(0), class = c(
-    "term",
-    "vctrs_vctr"
-  )), sample = integer(0), value = numeric(0)), row.names = integer(0), class = "data.frame"))
-  expect_identical(as_term_frame(nlists(nlist())), structure(list(term = structure(character(0), class = c(
-    "term",
-    "vctrs_vctr"
-  )), sample = integer(0), value = numeric(0)), row.names = integer(0), class = "data.frame"))
-  expect_identical(as_term_frame(nlists(nlist(x = 2))), structure(list(term = structure("x", class = c("term", "vctrs_vctr")), sample = 1L, value = 2), row.names = c(NA, -1L), class = "data.frame"))
-  expect_identical(as_term_frame(nlists(nlist(x = 2:4))), structure(list(term = structure(c("x[1]", "x[2]", "x[3]"), class = c(
-    "term",
-    "vctrs_vctr"
-  )), sample = c(1L, 1L, 1L), value = c(2, 3, 4)), row.names = c(
-    NA,
-    -3L
-  ), class = "data.frame"))
-  expect_identical(as_term_frame(nlists(nlist(y = 1, s = 1:2))), structure(list(term = structure(c("y", "s[1]", "s[2]"), class = c(
-    "term",
-    "vctrs_vctr"
-  )), sample = c(1L, 1L, 1L), value = c(1, 1, 2)), row.names = c(
-    NA,
-    -3L
-  ), class = "data.frame"))
-  expect_equal(as_term_frame(nlists(nlist(x = 1, y = 1:2), nlist(x = 1, y = 3:4))), structure(list(term = structure(c(
-    "x", "y[1]", "y[2]", "x", "y[1]",
-    "y[2]"
-  ), class = c("term", "vctrs_vctr")), sample = c(
-    1L, 1L,
-    1L, 2L, 2L, 2L
-  ), value = c(1, 1, 2, 1, 3, 4)), row.names = c(
-    NA,
-    -6L
-  ), class = "data.frame"))
+  expect_identical(
+    as_term_frame(nlists()),
+    structure(
+      list(
+        term = structure(
+          character(0),
+          class = c(
+            "term",
+            "vctrs_vctr"
+          )
+        ),
+        sample = integer(0),
+        value = numeric(0)
+      ),
+      row.names = integer(0),
+      class = "data.frame"
+    )
+  )
+  expect_identical(
+    as_term_frame(nlists(nlist())),
+    structure(
+      list(
+        term = structure(
+          character(0),
+          class = c(
+            "term",
+            "vctrs_vctr"
+          )
+        ),
+        sample = integer(0),
+        value = numeric(0)
+      ),
+      row.names = integer(0),
+      class = "data.frame"
+    )
+  )
+  expect_identical(
+    as_term_frame(nlists(nlist(x = 2))),
+    structure(
+      list(
+        term = structure("x", class = c("term", "vctrs_vctr")),
+        sample = 1L,
+        value = 2
+      ),
+      row.names = c(NA, -1L),
+      class = "data.frame"
+    )
+  )
+  expect_identical(
+    as_term_frame(nlists(nlist(x = 2:4))),
+    structure(
+      list(
+        term = structure(
+          c("x[1]", "x[2]", "x[3]"),
+          class = c(
+            "term",
+            "vctrs_vctr"
+          )
+        ),
+        sample = c(1L, 1L, 1L),
+        value = c(2, 3, 4)
+      ),
+      row.names = c(
+        NA,
+        -3L
+      ),
+      class = "data.frame"
+    )
+  )
+  expect_identical(
+    as_term_frame(nlists(nlist(y = 1, s = 1:2))),
+    structure(
+      list(
+        term = structure(
+          c("y", "s[1]", "s[2]"),
+          class = c(
+            "term",
+            "vctrs_vctr"
+          )
+        ),
+        sample = c(1L, 1L, 1L),
+        value = c(1, 1, 2)
+      ),
+      row.names = c(
+        NA,
+        -3L
+      ),
+      class = "data.frame"
+    )
+  )
+  expect_equal(
+    as_term_frame(nlists(nlist(x = 1, y = 1:2), nlist(x = 1, y = 3:4))),
+    structure(
+      list(
+        term = structure(
+          c(
+            "x",
+            "y[1]",
+            "y[2]",
+            "x",
+            "y[1]",
+            "y[2]"
+          ),
+          class = c("term", "vctrs_vctr")
+        ),
+        sample = c(
+          1L,
+          1L,
+          1L,
+          2L,
+          2L,
+          2L
+        ),
+        value = c(1, 1, 2, 1, 3, 4)
+      ),
+      row.names = c(
+        NA,
+        -6L
+      ),
+      class = "data.frame"
+    )
+  )
 })

--- a/tests/testthat/test-brackets.R
+++ b/tests/testthat/test-brackets.R
@@ -4,7 +4,9 @@ test_that("[.nlist", {
   expect_identical(nlist(x = 1, y = 2)["x"], nlist(x = 1))
   expect_identical(nlist(x = 1, y = 2)[2], nlist(y = 2))
   expect_identical(nlist(x = 1, y = 2)["y"], nlist(y = 2))
-  expect_error(nlist(x = 1, y = 2)[c(1, 1)], "^`names[(]x[)]` must be unique[.]$",
+  expect_error(
+    nlist(x = 1, y = 2)[c(1, 1)],
+    "^`names[(]x[)]` must be unique[.]$",
     class = "chk_error"
   )
   expect_error(nlist(x = 1)[1, ], "incorrect number of dimensions")
@@ -24,14 +26,17 @@ test_that("[.nlists", {
   expect_identical(nlists(nlist(x = 1))[1, 1], nlists(nlist(x = 1)))
   expect_identical(
     nlists(nlist(x = 1, y = 1), nlist(x = 2, y = 2))[1, 1],
-    structure(list(structure(list(x = 1, y = 1), class = "nlist")), class = "nlists")
+    structure(
+      list(structure(list(x = 1, y = 1), class = "nlist")),
+      class = "nlists"
+    )
   )
   expect_identical(
     nlists(nlist(x = 1, y = 1), nlist(x = 1, y = 1))[, 1],
     nlists(nlist(x = 1, y = 1))
   )
   expect_identical(
-    nlists(nlist(x = 1, y = 1), nlist(x = 1, y = 1))[, ],
+    nlists(nlist(x = 1, y = 1), nlist(x = 1, y = 1))[,],
     nlists(nlist(x = 1, y = 1), nlist(x = 1, y = 1))
   )
   expect_identical(
@@ -41,53 +46,109 @@ test_that("[.nlists", {
 })
 
 test_that("brackets with chains", {
-  nlists <- nlists(nlist(x = 1, y = 2), nlist(x = 2, y = 3), nlist(x = 3, y = 4), nlist(x = 4, y = 5))
+  nlists <- nlists(
+    nlist(x = 1, y = 2),
+    nlist(x = 2, y = 3),
+    nlist(x = 3, y = 4),
+    nlist(x = 4, y = 5)
+  )
   attr(nlists, "nchains") <- 2L
   expect_identical(nlists[1:2, 1:2], nlists)
   expect_identical(nlists[, 1:2], nlists)
   expect_identical(nlists[1:2, ], nlists)
-  expect_identical(nlists[, ], nlists)
-  expect_identical(nlists[], structure(list(
-    structure(list(x = 1, y = 2), class = "nlist"),
-    structure(list(x = 2, y = 3), class = "nlist"), structure(list(
-      x = 3, y = 4
-    ), class = "nlist"), structure(list(
-      x = 4,
-      y = 5
-    ), class = "nlist")
-  ), class = "nlists"))
+  expect_identical(nlists[,], nlists)
+  expect_identical(
+    nlists[],
+    structure(
+      list(
+        structure(list(x = 1, y = 2), class = "nlist"),
+        structure(list(x = 2, y = 3), class = "nlist"),
+        structure(
+          list(
+            x = 3,
+            y = 4
+          ),
+          class = "nlist"
+        ),
+        structure(
+          list(
+            x = 4,
+            y = 5
+          ),
+          class = "nlist"
+        )
+      ),
+      class = "nlists"
+    )
+  )
   expect_identical(
     subset(nlists, pars = c("y", "x")),
-    structure(list(
-      structure(list(y = 2, x = 1), class = "nlist"),
-      structure(list(y = 3, x = 2), class = "nlist"), structure(list(
-        y = 4, x = 3
-      ), class = "nlist"), structure(list(
-        y = 5,
-        x = 4
-      ), class = "nlist")
-    ), class = "nlists", nchains = 2L)
+    structure(
+      list(
+        structure(list(y = 2, x = 1), class = "nlist"),
+        structure(list(y = 3, x = 2), class = "nlist"),
+        structure(
+          list(
+            y = 4,
+            x = 3
+          ),
+          class = "nlist"
+        ),
+        structure(
+          list(
+            y = 5,
+            x = 4
+          ),
+          class = "nlist"
+        )
+      ),
+      class = "nlists",
+      nchains = 2L
+    )
   )
   expect_identical(
     subset(nlists, chains = c(1, 1, 1)),
-    structure(list(
-      structure(list(x = 1, y = 2), class = "nlist"),
-      structure(list(x = 2, y = 3), class = "nlist"), structure(list(
-        x = 1, y = 2
-      ), class = "nlist"), structure(list(
-        x = 2,
-        y = 3
-      ), class = "nlist"), structure(list(x = 1, y = 2), class = "nlist"),
-      structure(list(x = 2, y = 3), class = "nlist")
-    ), class = "nlists", nchains = 3L)
+    structure(
+      list(
+        structure(list(x = 1, y = 2), class = "nlist"),
+        structure(list(x = 2, y = 3), class = "nlist"),
+        structure(
+          list(
+            x = 1,
+            y = 2
+          ),
+          class = "nlist"
+        ),
+        structure(
+          list(
+            x = 2,
+            y = 3
+          ),
+          class = "nlist"
+        ),
+        structure(list(x = 1, y = 2), class = "nlist"),
+        structure(list(x = 2, y = 3), class = "nlist")
+      ),
+      class = "nlists",
+      nchains = 3L
+    )
   )
   expect_identical(
     subset(nlists, pars = "x", iters = c(2, 2)),
-    structure(list(
-      structure(list(x = 2), class = "nlist"), structure(list(
-        x = 2
-      ), class = "nlist"), structure(list(x = 4), class = "nlist"),
-      structure(list(x = 4), class = "nlist")
-    ), class = "nlists", nchains = 2L)
+    structure(
+      list(
+        structure(list(x = 2), class = "nlist"),
+        structure(
+          list(
+            x = 2
+          ),
+          class = "nlist"
+        ),
+        structure(list(x = 4), class = "nlist"),
+        structure(list(x = 4), class = "nlist")
+      ),
+      class = "nlists",
+      nchains = 2L
+    )
   )
 })

--- a/tests/testthat/test-c.R
+++ b/tests/testthat/test-c.R
@@ -1,7 +1,8 @@
 test_that("c.nlist", {
   expect_identical(c(nlist()), nlist())
   expect_identical(c(nlist(x = 1)), nlist(x = 1))
-  expect_error(c(nlist(x = 1), list(x = 1)),
+  expect_error(
+    c(nlist(x = 1), list(x = 1)),
     "^All elements of ... must inherit from S3 class 'nlist'",
     class = "chk_error"
   )
@@ -25,7 +26,8 @@ test_that("c.nlists", {
     ),
     nlists(nlist(x = 1), nlist(x = 1))
   )
-  expect_error(c(nlists(), list()),
+  expect_error(
+    c(nlists(), list()),
     "^All elements of ... must inherit from S3 class 'nlists'",
     class = "chk_error"
   )
@@ -57,12 +59,21 @@ test_that("c.nlists with same nchains", {
   attr(nlists2, "nchains") <- 2L
   expect_identical(
     c(nlists, nlists2),
-    structure(list(
-      structure(list(x = 1), class = "nlist"), structure(list(
-        x = 3
-      ), class = "nlist"), structure(list(x = 2), class = "nlist"),
-      structure(list(x = 4), class = "nlist")
-    ), class = "nlists", nchains = 2L)
+    structure(
+      list(
+        structure(list(x = 1), class = "nlist"),
+        structure(
+          list(
+            x = 3
+          ),
+          class = "nlist"
+        ),
+        structure(list(x = 2), class = "nlist"),
+        structure(list(x = 4), class = "nlist")
+      ),
+      class = "nlists",
+      nchains = 2L
+    )
   )
 })
 
@@ -73,13 +84,24 @@ test_that("c.nlists with same nchains", {
   attr(nlists2, "nchains") <- 2L
   expect_identical(
     c(nlists, nlists2),
-    structure(list(
-      structure(list(x = 1), class = "nlist"), structure(list(
-        x = 2
-      ), class = "nlist"), structure(list(x = 5), class = "nlist"),
-      structure(list(x = 6), class = "nlist"), structure(list(x = 3), class = "nlist"),
-      structure(list(x = 4), class = "nlist"), structure(list(x = 7), class = "nlist"),
-      structure(list(x = 8), class = "nlist")
-    ), class = "nlists", nchains = 2L)
+    structure(
+      list(
+        structure(list(x = 1), class = "nlist"),
+        structure(
+          list(
+            x = 2
+          ),
+          class = "nlist"
+        ),
+        structure(list(x = 5), class = "nlist"),
+        structure(list(x = 6), class = "nlist"),
+        structure(list(x = 3), class = "nlist"),
+        structure(list(x = 4), class = "nlist"),
+        structure(list(x = 7), class = "nlist"),
+        structure(list(x = 8), class = "nlist")
+      ),
+      class = "nlists",
+      nchains = 2L
+    )
   )
 })

--- a/tests/testthat/test-chk.R
+++ b/tests/testthat/test-chk.R
@@ -1,17 +1,23 @@
 test_that("chk_nlist", {
-  expect_error(chk_nlist(NULL),
+  expect_error(
+    chk_nlist(NULL),
     "^`NULL` must inherit from S3 class 'nlist'",
     class = "chk_error"
   )
   expect_false(vld_nlist(list()))
   expect_false(vld_nlist(list(x = 1, x = 2)))
-  expect_error(chk_nlist(list(x = 1, x = 2)), "^`list[(]x = 1, x = 2[)]` must inherit from S3 class 'nlist'", class = "chk_error")
+  expect_error(
+    chk_nlist(list(x = 1, x = 2)),
+    "^`list[(]x = 1, x = 2[)]` must inherit from S3 class 'nlist'",
+    class = "chk_error"
+  )
   expect_true(vld_nlist(nlist(x = 1, y = 2)))
   expect_true(vld_nlist(nlist(x = 1)[-1]))
   expect_true(vld_nlist(nlist()))
   expect_true(vld_nlist(nlist(x = 1)))
   expect_false(vld_nlist(list(x = TRUE)))
-  expect_error(chk_nlist(list(x = TRUE)),
+  expect_error(
+    chk_nlist(list(x = TRUE)),
     "`list[(]x = TRUE[)]` must inherit from S3 class 'nlist'",
     class = "chk_error"
   )
@@ -21,27 +27,40 @@ test_that("chk_nlist", {
 })
 
 test_that("chk_nlists", {
-  expect_error(chk_nlists(list()), "^`list[(][)]` must inherit from S3 class 'nlists'", class = "chk_error")
+  expect_error(
+    chk_nlists(list()),
+    "^`list[(][)]` must inherit from S3 class 'nlists'",
+    class = "chk_error"
+  )
   expect_true(vld_nlists(nlists()))
-  expect_error(chk_nlists(list(nlist(x = 1))), "^`[^`]+` must inherit from S3 class 'nlists'", class = "chk_error")
+  expect_error(
+    chk_nlists(list(nlist(x = 1))),
+    "^`[^`]+` must inherit from S3 class 'nlists'",
+    class = "chk_error"
+  )
   expect_true(vld_nlists(nlists(nlist())))
   expect_true(vld_nlists(nlists(nlist(x = 1), nlist(x = 2))))
   expect_true(vld_nlists(nlists(nlist(x = 1), nlist(x = 2))))
-  expect_error(nlists(nlist(x = 1), nlist(y = 2)),
+  expect_error(
+    nlists(nlist(x = 1), nlist(y = 2)),
     "^nlist elements of `x` must have matching names[.]",
     class = "chk_error"
   )
-  expect_error(nlists(nlist(x = 1), nlist(x = 1L)),
+  expect_error(
+    nlists(nlist(x = 1), nlist(x = 1L)),
     "^nlist elements of `x` must have matching types[.]",
     class = "chk_error"
   )
-  expect_error(nlists(nlist(x = 1L), nlist(x = 1:2)),
+  expect_error(
+    nlists(nlist(x = 1L), nlist(x = 1:2)),
     "^nlist elements of `x` must have matching dimensions[.]",
     class = "chk_error"
   )
   x <- list(x = "x")
   class(x) <- "nlist"
-  expect_error(chk_nlist(x), "All elements of `x` must be numeric.",
+  expect_error(
+    chk_nlist(x),
+    "All elements of `x` must be numeric.",
     class = "chk_error"
   )
   x <- list("x")

--- a/tests/testthat/test-estimates.R
+++ b/tests/testthat/test-estimates.R
@@ -1,12 +1,25 @@
 test_that("estimates.nlist", {
-  expect_identical(estimates(nlist()), structure(list(), .Names = character(0), class = "nlist"))
+  expect_identical(
+    estimates(nlist()),
+    structure(list(), .Names = character(0), class = "nlist")
+  )
   expect_identical(estimates(nlist(x = 1)), nlist(x = 1))
   expect_identical(estimates(nlist(x = 1:2)), nlist(x = 1:2))
   expect_identical(estimates(nlist(z = 1:2), fun = median), nlist(z = 1:2))
-  expect_identical(estimates(nlist(z = 1:2), fun = function(x) 1L), nlist(z = c(1L, 1L)))
-  expect_identical(estimates(nlist(z = 1:2), fun = function(x, value) {
-    value
-  }, value = 2.5), nlist(z = c(2.5, 2.5)))
+  expect_identical(
+    estimates(nlist(z = 1:2), fun = function(x) 1L),
+    nlist(z = c(1L, 1L))
+  )
+  expect_identical(
+    estimates(
+      nlist(z = 1:2),
+      fun = function(x, value) {
+        value
+      },
+      value = 2.5
+    ),
+    nlist(z = c(2.5, 2.5))
+  )
 
   expect_error(
     estimates(nlist(x = 1:2), fun = function(x) 1:2),
@@ -24,26 +37,57 @@ test_that("estimates.nlists", {
     estimates(nlists(nlist())),
     structure(list(), .Names = character(0), class = "nlist")
   )
-  expect_identical(estimates(nlists(nlist(x = 1), nlist(x = 2))), nlist(x = 1.5))
+  expect_identical(
+    estimates(nlists(nlist(x = 1), nlist(x = 2))),
+    nlist(x = 1.5)
+  )
   expect_identical(
     estimates(nlists(
       nlist(x = matrix(1:9, 3)),
       nlist(x = matrix(2:10, 3))
     )),
-    structure(list(x = structure(c(
-      1.5, 2.5, 3.5, 4.5, 5.5, 6.5,
-      7.5, 8.5, 9.5
-    ), .Dim = c(3L, 3L))), class = "nlist")
+    structure(
+      list(
+        x = structure(
+          c(
+            1.5,
+            2.5,
+            3.5,
+            4.5,
+            5.5,
+            6.5,
+            7.5,
+            8.5,
+            9.5
+          ),
+          .Dim = c(3L, 3L)
+        )
+      ),
+      class = "nlist"
+    )
   )
-  expect_identical(estimates(nlists(nlist(x = 1), nlist(x = 2)), fun = function(x) x[1]), nlist(x = 1))
+  expect_identical(
+    estimates(nlists(nlist(x = 1), nlist(x = 2)), fun = function(x) x[1]),
+    nlist(x = 1)
+  )
 
-  expect_identical(estimates(nlists(nlist(x = 1), nlist(x = 2)), fun = function(x, value) value, value = 3), nlist(x = 3))
+  expect_identical(
+    estimates(
+      nlists(nlist(x = 1), nlist(x = 2)),
+      fun = function(x, value) value,
+      value = 3
+    ),
+    nlist(x = 3)
+  )
 
   expect_error(
-    estimates(nlists(
-      nlist(x = matrix(1:9, 3)),
-      nlist(x = matrix(2:10, 3))
-    ), fun = identity),
+    estimates(
+      nlists(
+        nlist(x = matrix(1:9, 3)),
+        nlist(x = matrix(2:10, 3))
+      ),
+      fun = identity
+    ),
     "^`fun` must return a scalar[.]$",
     class = "chk_error"
   )

--- a/tests/testthat/test-nlists.R
+++ b/tests/testthat/test-nlists.R
@@ -6,29 +6,34 @@ test_that("nlists", {
 
   expect_identical(
     nlists(nlist()),
-    structure(list(structure(list(),
-      .Names = character(0),
-      class = "nlist"
-    )), class = "nlists")
+    structure(
+      list(structure(list(), .Names = character(0), class = "nlist")),
+      class = "nlists"
+    )
   )
   expect_identical(
     nlists(nlist(x = 1)),
-    structure(list(structure(list(x = 1), class = "nlist")),
-      class = "nlists"
-    )
+    structure(list(structure(list(x = 1), class = "nlist")), class = "nlists")
   )
 
   expect_identical(
     nlists(nlist(x = 1), nlist(x = 2)),
-    structure(list(
-      structure(list(x = 1), class = "nlist"),
-      structure(list(
-        x = 2
-      ), class = "nlist")
-    ), class = "nlists")
+    structure(
+      list(
+        structure(list(x = 1), class = "nlist"),
+        structure(
+          list(
+            x = 2
+          ),
+          class = "nlist"
+        )
+      ),
+      class = "nlists"
+    )
   )
 
-  expect_error(nlists(nlist(x = 1), nlist(y = 2)),
+  expect_error(
+    nlists(nlist(x = 1), nlist(y = 2)),
     "^nlist elements of `x` must have matching names[.]$",
     class = "chk_error"
   )

--- a/tests/testthat/test-nsams.R
+++ b/tests/testthat/test-nsams.R
@@ -14,8 +14,11 @@ test_that("nsams.nlists", {
   expect_identical(nsams(nlists(nlist(x = 2:3))), 2L)
   expect_identical(nsams(nlists(nlist(x = 2:3, y = 1))), 3L)
   expect_identical(nsams(nlists(nlist(x = 2:3, y = matrix(1:9)))), 11L)
-  expect_identical(nsams(nlists(
-    nlist(x = 2:3, y = matrix(1:9)),
-    nlist(x = 2:3, y = matrix(1:9))
-  )), 22L)
+  expect_identical(
+    nsams(nlists(
+      nlist(x = 2:3, y = matrix(1:9)),
+      nlist(x = 2:3, y = matrix(1:9))
+    )),
+    22L
+  )
 })

--- a/tests/testthat/test-nterms.R
+++ b/tests/testthat/test-nterms.R
@@ -14,8 +14,11 @@ test_that("nterms.nlists", {
   expect_identical(nterms(nlists(nlist(x = 2:3))), 2L)
   expect_identical(nterms(nlists(nlist(x = 2:3, y = 1))), 3L)
   expect_identical(nterms(nlists(nlist(x = 2:3, y = matrix(1:9)))), 11L)
-  expect_identical(nterms(nlists(
-    nlist(x = 2:3, y = matrix(1:9)),
-    nlist(x = 2:3, y = matrix(1:9))
-  )), 11L)
+  expect_identical(
+    nterms(nlists(
+      nlist(x = 2:3, y = matrix(1:9)),
+      nlist(x = 2:3, y = matrix(1:9))
+    )),
+    11L
+  )
 })

--- a/tests/testthat/test-pars.R
+++ b/tests/testthat/test-pars.R
@@ -19,10 +19,13 @@ test_that("pars.nlists", {
   expect_identical(pars(nlists(nlist(x = 1))), "x")
   expect_identical(pars(nlists(nlist(x = 1), nlist(x = 1))), "x")
   expect_identical(pars(nlists(nlist(x = 1, a = 1:10))), c("x", "a"))
-  expect_identical(pars(nlists(
-    nlist(x = 1, a = 1:10),
-    nlist(x = 1, a = 1:10)
-  )), c("x", "a"))
+  expect_identical(
+    pars(nlists(
+      nlist(x = 1, a = 1:10),
+      nlist(x = 1, a = 1:10)
+    )),
+    c("x", "a")
+  )
 })
 
 test_that("pars.nlist scalar", {
@@ -38,12 +41,21 @@ test_that("pars.nlists scalar", {
   expect_identical(pars(nlists(nlist(), nlist()), scalar = TRUE), character(0))
   expect_identical(pars(nlists(nlist(x = 1, a = 1:10)), scalar = TRUE), "x")
   expect_identical(pars(nlists(nlist(a = 1:10)), scalar = TRUE), character(0))
-  expect_identical(pars(nlists(nlist(x = 1, a = 1:10), nlist(x = 2, a = 1:10)), scalar = TRUE), "x")
+  expect_identical(
+    pars(nlists(nlist(x = 1, a = 1:10), nlist(x = 2, a = 1:10)), scalar = TRUE),
+    "x"
+  )
 })
 
 test_that("pars.nlists term", {
   rlang::local_options(lifecycle_verbosity = "quiet")
-  lifecycle::expect_deprecated(pars(nlists(nlist(x = 1, a = 1:2)), terms = TRUE))
+  lifecycle::expect_deprecated(pars(
+    nlists(nlist(x = 1, a = 1:2)),
+    terms = TRUE
+  ))
 
-  expect_identical(pars(nlists(nlist(x = 1, a = 1:2)), terms = TRUE), c("x", "a", "a"))
+  expect_identical(
+    pars(nlists(nlist(x = 1, a = 1:2)), terms = TRUE),
+    c("x", "a", "a")
+  )
 })

--- a/tests/testthat/test-print.R
+++ b/tests/testthat/test-print.R
@@ -11,8 +11,15 @@ test_that("print.nlist", {
   expect_identical(
     capture.output(print(nlist(x = 1, y = matrix(1:4, 2)))),
     c(
-      "$x", "[1] 1", "", "$y", "     [,1] [,2]", "[1,]    1    3",
-      "[2,]    2    4", "", "an nlist object with 2 numeric elements"
+      "$x",
+      "[1] 1",
+      "",
+      "$y",
+      "     [,1] [,2]",
+      "[1,]    1    3",
+      "[2,]    2    4",
+      "",
+      "an nlist object with 2 numeric elements"
     )
   )
 })
@@ -35,8 +42,15 @@ test_that("print.nlists", {
   expect_identical(
     capture.output(print(nlists)),
     c(
-      "$x", "[1] 1", "", "$y", "     [,1] [,2]", "[1,]    1    3",
-      "[2,]    2    4", "", "an nlists object of 2 nlist objects each with 2 numeric elements"
+      "$x",
+      "[1] 1",
+      "",
+      "$y",
+      "     [,1] [,2]",
+      "[1,]    1    3",
+      "[2,]    2    4",
+      "",
+      "an nlists object of 2 nlist objects each with 2 numeric elements"
     )
   )
 })
@@ -51,8 +65,15 @@ test_that("print.nlists multiple chains", {
   expect_identical(
     capture.output(print(nlists)),
     c(
-      "$x", "[1] 1", "", "$y", "     [,1] [,2]", "[1,]    1    3",
-      "[2,]    2    4", "", "an nlists object with 2 chains of an nlist object with 2 numeric elements"
+      "$x",
+      "[1] 1",
+      "",
+      "$y",
+      "     [,1] [,2]",
+      "[1,]    1    3",
+      "[2,]    2    4",
+      "",
+      "an nlists object with 2 chains of an nlist object with 2 numeric elements"
     )
   )
 })

--- a/tests/testthat/test-relist-nlist.R
+++ b/tests/testthat/test-relist-nlist.R
@@ -1,8 +1,11 @@
 test_that("relist_nlist", {
-  expect_identical(relist_nlist(
-    structure(numeric(0), .Names = character(0)),
+  expect_identical(
+    relist_nlist(
+      structure(numeric(0), .Names = character(0)),
+      nlist()
+    ),
     nlist()
-  ), nlist())
+  )
   expect_identical(
     relist_nlist(c(a = 5), nlist(a = NA_real_)),
     nlist(a = 5)

--- a/tests/testthat/test-set-pars.R
+++ b/tests/testthat/test-set-pars.R
@@ -10,12 +10,14 @@ test_that("nlist", {
 
   x <- nlist()
   expect_identical(set_pars(x, character(0)), x)
-  expect_error(set_pars(x, "a"),
+  expect_error(
+    set_pars(x, "a"),
     "^`value` must be length 0, not 1[.]$",
     class = "chk_error"
   )
   x <- nlist(x = 2)
-  expect_error(set_pars(x, "."),
+  expect_error(
+    set_pars(x, "."),
     "^`value` must match regular expression",
     class = "chk_error"
   )
@@ -24,7 +26,11 @@ test_that("nlist", {
 test_that("nlists", {
   x <- nlists()
   expect_identical(set_pars(x, character(0)), x)
-  expect_error(set_pars(x, "a"), "^`value` must be length 0, not 1[.]$", class = "chk_error")
+  expect_error(
+    set_pars(x, "a"),
+    "^`value` must be length 0, not 1[.]$",
+    class = "chk_error"
+  )
   x <- nlists(nlist())
   expect_identical(set_pars(x, character(0)), x)
 
@@ -36,11 +42,21 @@ test_that("nlists", {
   x <- nlists(nlist(x = 2), nlist(x = 3))
   expect_identical(
     set_pars(x, "y"),
-    structure(list(structure(list(y = 2), class = "nlist"), structure(list(
-      y = 3
-    ), class = "nlist")), class = "nlists")
+    structure(
+      list(
+        structure(list(y = 2), class = "nlist"),
+        structure(
+          list(
+            y = 3
+          ),
+          class = "nlist"
+        )
+      ),
+      class = "nlists"
+    )
   )
-  expect_error(set_pars(x, "."),
+  expect_error(
+    set_pars(x, "."),
     "^`value` must match regular expression",
     class = "chk_error"
   )

--- a/tests/testthat/test-split-chains.R
+++ b/tests/testthat/test-split-chains.R
@@ -8,21 +8,28 @@ test_that("split_chains nlists", {
 
 test_that("split_chains nlists error", {
   nlists <- nlists(nlist(x = matrix(1:6, 2)))
-  expect_error(split_chains(nlists), "^`x` must have at least two iterations[.]$",
+  expect_error(
+    split_chains(nlists),
+    "^`x` must have at least two iterations[.]$",
     class = "chk_error"
   )
 })
 
 test_that("split_chains nlists extra iters", {
   nlists <- nlists(
-    nlist(x = matrix(1:6, 2)), nlist(x = matrix(3:8, 2)),
+    nlist(x = matrix(1:6, 2)),
+    nlist(x = matrix(3:8, 2)),
     nlist(x = matrix(2:7, 2))
   )
   expect_identical(
     split_chains(nlists),
-    structure(list(
-      structure(list(x = structure(1:6, .Dim = 2:3)), class = "nlist"),
-      structure(list(x = structure(3:8, .Dim = 2:3)), class = "nlist")
-    ), class = "nlists", nchains = 2L)
+    structure(
+      list(
+        structure(list(x = structure(1:6, .Dim = 2:3)), class = "nlist"),
+        structure(list(x = structure(3:8, .Dim = 2:3)), class = "nlist")
+      ),
+      class = "nlists",
+      nchains = 2L
+    )
   )
 })

--- a/tests/testthat/test-subset.R
+++ b/tests/testthat/test-subset.R
@@ -8,12 +8,17 @@ test_that("subset.mcmc", {
     as_mcmc(nlist(beta = 1:2))
   )
 
-  expect_equal(subset(as_mcmc(nlists(nlist(beta = 1:2), nlist(beta = 3:4))), iters = 1),
+  expect_equal(
+    subset(as_mcmc(nlists(nlist(beta = 1:2), nlist(beta = 3:4))), iters = 1),
     as_mcmc(nlists(nlist(beta = 1:2))),
     ignore_attr = TRUE
   )
 
-  expect_equal(subset(as_mcmc(nlists(nlist(beta = 1:2), nlist(beta = 3:4))), iters = c(1, 1)),
+  expect_equal(
+    subset(
+      as_mcmc(nlists(nlist(beta = 1:2), nlist(beta = 3:4))),
+      iters = c(1, 1)
+    ),
     as_mcmc(nlists(nlist(beta = 1:2), nlist(beta = 1:2))),
     ignore_attr = TRUE
   )
@@ -37,7 +42,8 @@ test_that("subset.mcmc.list", {
       nlist(beta = 3:4)
     ))
   )
-  expect_equal(subset(mcmc.list, iters = c(1L, 1L)),
+  expect_equal(
+    subset(mcmc.list, iters = c(1L, 1L)),
     as_mcmc_list(nlists(
       nlist(beta = 1:2, theta = 1),
       nlist(beta = 1:2, theta = 1)
@@ -49,7 +55,11 @@ test_that("subset.mcmc.list", {
     subset(as_mcmc_list(nlist(beta = 1:2, theta = 1)), pars = "beta"),
     as_mcmc_list(nlist(beta = 1:2))
   )
-  expect_equal(subset(as_mcmc_list(nlists(nlist(beta = 1:2), nlist(beta = 3:4))), iters = 1),
+  expect_equal(
+    subset(
+      as_mcmc_list(nlists(nlist(beta = 1:2), nlist(beta = 3:4))),
+      iters = 1
+    ),
     as_mcmc_list(nlists(nlist(beta = 1:2))),
     ignore_attr = TRUE
   )
@@ -60,7 +70,8 @@ test_that("subset.mcmc.list", {
     subset(as_mcmc_list(nlists), chains = 1:2),
     as_mcmc_list(nlists)
   )
-  expect_equal(subset(as_mcmc_list(nlists), chains = 2),
+  expect_equal(
+    subset(as_mcmc_list(nlists), chains = 2),
     as_mcmc_list(subset(nlists, chains = 2)),
     ignore_attr = TRUE
   )
@@ -71,9 +82,16 @@ test_that("subset.nlist", {
   expect_identical(subset(nlist(x = 1)), nlist(x = 1))
   expect_identical(subset(nlist(x = 1, y = 2), pars = "x"), nlist(x = 1))
   expect_identical(subset(nlist(x = 1, y = 2), pars = "y"), nlist(y = 2))
-  expect_identical(subset(nlist(x = 1, y = 2), pars = c("y", "x")), nlist(y = 2, x = 1))
-  expect_identical(subset(nlist(x = 1, y = 2), pars = c("x", "y")), nlist(x = 1, y = 2))
-  expect_error(subset(nlist(x = 1, y = 2), pars = "z"),
+  expect_identical(
+    subset(nlist(x = 1, y = 2), pars = c("y", "x")),
+    nlist(y = 2, x = 1)
+  )
+  expect_identical(
+    subset(nlist(x = 1, y = 2), pars = c("x", "y")),
+    nlist(x = 1, y = 2)
+  )
+  expect_error(
+    subset(nlist(x = 1, y = 2), pars = "z"),
     "^`pars` must match 'x' or 'y', not 'z'[.]$",
     class = "chk_error"
   )
@@ -83,11 +101,23 @@ test_that("subset.nlists pars and iters", {
   expect_identical(subset(nlists()), nlists())
   expect_identical(subset(nlists(nlist())), nlists(nlist()))
   expect_identical(subset(nlists(nlist(x = 1))), nlists(nlist(x = 1)))
-  expect_identical(subset(nlists(nlist(x = 1, y = 2)), pars = "x"), nlists(nlist(x = 1)))
-  expect_identical(subset(nlists(nlist(x = 1, y = 2)), pars = "y"), nlists(nlist(y = 2)))
-  expect_identical(subset(nlists(nlist(x = 1, y = 2), nlist(x = 3, y = 2)), pars = "x"), nlists(nlist(x = 1), nlist(x = 3)))
   expect_identical(
-    subset(nlists(nlist(x = 1, y = 2), nlist(x = 3, y = 2)), pars = c("y", "x")),
+    subset(nlists(nlist(x = 1, y = 2)), pars = "x"),
+    nlists(nlist(x = 1))
+  )
+  expect_identical(
+    subset(nlists(nlist(x = 1, y = 2)), pars = "y"),
+    nlists(nlist(y = 2))
+  )
+  expect_identical(
+    subset(nlists(nlist(x = 1, y = 2), nlist(x = 3, y = 2)), pars = "x"),
+    nlists(nlist(x = 1), nlist(x = 3))
+  )
+  expect_identical(
+    subset(
+      nlists(nlist(x = 1, y = 2), nlist(x = 3, y = 2)),
+      pars = c("y", "x")
+    ),
     subset(nlists(nlist(y = 2, x = 1), nlist(y = 2, x = 3)))
   )
   expect_identical(
@@ -103,18 +133,30 @@ test_that("subset.nlists pars and iters", {
     subset(nlists(nlist(x = 3, y = 2), nlist(x = 1, y = 2)))
   )
   expect_identical(
-    subset(nlists(nlist(x = 1, y = 2), nlist(x = 3, y = 2)), iters = c(2L, 1L), pars = "x"),
+    subset(
+      nlists(nlist(x = 1, y = 2), nlist(x = 3, y = 2)),
+      iters = c(2L, 1L),
+      pars = "x"
+    ),
     subset(nlists(nlist(x = 3), nlist(x = 1)))
   )
   expect_identical(
-    subset(nlists(nlist(x = 1, y = 2), nlist(x = 3, y = 2)), iters = integer(0)),
+    subset(
+      nlists(nlist(x = 1, y = 2), nlist(x = 3, y = 2)),
+      iters = integer(0)
+    ),
     subset(nlists())
   )
   expect_identical(
-    subset(nlists(nlist(x = 1, y = 2), nlist(x = 3, y = 2)), iters = integer(0), pars = "x"),
+    subset(
+      nlists(nlist(x = 1, y = 2), nlist(x = 3, y = 2)),
+      iters = integer(0),
+      pars = "x"
+    ),
     subset(nlists())
   )
-  expect_error(subset(nlists(nlist(x = 1, y = 2)), pars = "z"),
+  expect_error(
+    subset(nlists(nlist(x = 1, y = 2)), pars = "z"),
     "^`pars` must match 'x' or 'y', not 'z'[.]$",
     class = "chk_error"
   )
@@ -122,41 +164,82 @@ test_that("subset.nlists pars and iters", {
 
 
 test_that("subset with chains", {
-  nlists <- nlists(nlist(x = 1, y = 2), nlist(x = 2, y = 3), nlist(x = 3, y = 4), nlist(x = 4, y = 5))
+  nlists <- nlists(
+    nlist(x = 1, y = 2),
+    nlist(x = 2, y = 3),
+    nlist(x = 3, y = 4),
+    nlist(x = 4, y = 5)
+  )
   attr(nlists, "nchains") <- 2L
   expect_identical(subset(nlists), nlists)
   expect_identical(
     subset(nlists, pars = c("y", "x")),
-    structure(list(
-      structure(list(y = 2, x = 1), class = "nlist"),
-      structure(list(y = 3, x = 2), class = "nlist"), structure(list(
-        y = 4, x = 3
-      ), class = "nlist"), structure(list(
-        y = 5,
-        x = 4
-      ), class = "nlist")
-    ), class = "nlists", nchains = 2L)
+    structure(
+      list(
+        structure(list(y = 2, x = 1), class = "nlist"),
+        structure(list(y = 3, x = 2), class = "nlist"),
+        structure(
+          list(
+            y = 4,
+            x = 3
+          ),
+          class = "nlist"
+        ),
+        structure(
+          list(
+            y = 5,
+            x = 4
+          ),
+          class = "nlist"
+        )
+      ),
+      class = "nlists",
+      nchains = 2L
+    )
   )
   expect_identical(
     subset(nlists, chains = c(1, 1, 1)),
-    structure(list(
-      structure(list(x = 1, y = 2), class = "nlist"),
-      structure(list(x = 2, y = 3), class = "nlist"), structure(list(
-        x = 1, y = 2
-      ), class = "nlist"), structure(list(
-        x = 2,
-        y = 3
-      ), class = "nlist"), structure(list(x = 1, y = 2), class = "nlist"),
-      structure(list(x = 2, y = 3), class = "nlist")
-    ), class = "nlists", nchains = 3L)
+    structure(
+      list(
+        structure(list(x = 1, y = 2), class = "nlist"),
+        structure(list(x = 2, y = 3), class = "nlist"),
+        structure(
+          list(
+            x = 1,
+            y = 2
+          ),
+          class = "nlist"
+        ),
+        structure(
+          list(
+            x = 2,
+            y = 3
+          ),
+          class = "nlist"
+        ),
+        structure(list(x = 1, y = 2), class = "nlist"),
+        structure(list(x = 2, y = 3), class = "nlist")
+      ),
+      class = "nlists",
+      nchains = 3L
+    )
   )
   expect_identical(
     subset(nlists, pars = "x", iters = c(2, 2)),
-    structure(list(
-      structure(list(x = 2), class = "nlist"), structure(list(
-        x = 2
-      ), class = "nlist"), structure(list(x = 4), class = "nlist"),
-      structure(list(x = 4), class = "nlist")
-    ), class = "nlists", nchains = 2L)
+    structure(
+      list(
+        structure(list(x = 2), class = "nlist"),
+        structure(
+          list(
+            x = 2
+          ),
+          class = "nlist"
+        ),
+        structure(list(x = 4), class = "nlist"),
+        structure(list(x = 4), class = "nlist")
+      ),
+      class = "nlists",
+      nchains = 2L
+    )
   )
 })

--- a/tests/testthat/test-thin.R
+++ b/tests/testthat/test-thin.R
@@ -1,8 +1,20 @@
 test_that("thin", {
   expect_identical(
-    thin(nlists(nlist(x = 1L), nlist(x = 2L), nlist(x = 3L), nlist(x = 4L)), nthin = 2),
-    structure(list(structure(list(x = 1L), class = "nlist"), structure(list(
-      x = 3L
-    ), class = "nlist")), class = "nlists")
+    thin(
+      nlists(nlist(x = 1L), nlist(x = 2L), nlist(x = 3L), nlist(x = 4L)),
+      nthin = 2
+    ),
+    structure(
+      list(
+        structure(list(x = 1L), class = "nlist"),
+        structure(
+          list(
+            x = 3L
+          ),
+          class = "nlist"
+        )
+      ),
+      class = "nlists"
+    )
   )
 })

--- a/tests/testthat/test-tidy.R
+++ b/tests/testthat/test-tidy.R
@@ -3,111 +3,221 @@ test_that("tidy.nlists", {
 
   lifecycle::expect_deprecated(tidy(nlists(), directional_information = FALSE))
 
-  expect_identical(tidy(nlists()), structure(list(
-    term = structure(character(0), class = c(
-      "term",
-      "vctrs_vctr"
-    )), estimate = numeric(0), sd = numeric(0), zscore = numeric(0),
-    lower = numeric(0), upper = numeric(0), svalue = numeric(0)
-  ), row.names = integer(0), class = c(
-    "tbl_df",
-    "tbl", "data.frame"
-  )))
+  expect_identical(
+    tidy(nlists()),
+    structure(
+      list(
+        term = structure(
+          character(0),
+          class = c(
+            "term",
+            "vctrs_vctr"
+          )
+        ),
+        estimate = numeric(0),
+        sd = numeric(0),
+        zscore = numeric(0),
+        lower = numeric(0),
+        upper = numeric(0),
+        svalue = numeric(0)
+      ),
+      row.names = integer(0),
+      class = c(
+        "tbl_df",
+        "tbl",
+        "data.frame"
+      )
+    )
+  )
   expect_equal(
     tidy(nlists(nlist())),
     tibble::tibble(
-      term = term(x = 0), estimate = numeric(0), sd = numeric(0), zscore = numeric(0),
-      lower = numeric(0), upper = numeric(0), svalue = numeric(0)
+      term = term(x = 0),
+      estimate = numeric(0),
+      sd = numeric(0),
+      zscore = numeric(0),
+      lower = numeric(0),
+      upper = numeric(0),
+      svalue = numeric(0)
     )
   )
   expect_identical(
     tidy(nlists(nlist(x = 2))),
     tibble::tibble(
-      term = term("x"), estimate = 2, sd = NA_real_, zscore = NA_real_, lower = 2,
-      upper = 2, svalue = 1
+      term = term("x"),
+      estimate = 2,
+      sd = NA_real_,
+      zscore = NA_real_,
+      lower = 2,
+      upper = 2,
+      svalue = 1
     )
   )
   expect_identical(
     tidy(nlists(nlist(x = 2:4))),
-    tibble::tibble(term = term(x = 3), estimate = c(2, 3, 4), sd = c(
-      NA_real_, NA_real_,
-      NA_real_
-    ), zscore = c(NA_real_, NA_real_, NA_real_), lower = c(
-      2,
-      3, 4
-    ), upper = c(2, 3, 4), svalue = c(1, 1, 1))
+    tibble::tibble(
+      term = term(x = 3),
+      estimate = c(2, 3, 4),
+      sd = c(
+        NA_real_,
+        NA_real_,
+        NA_real_
+      ),
+      zscore = c(NA_real_, NA_real_, NA_real_),
+      lower = c(
+        2,
+        3,
+        4
+      ),
+      upper = c(2, 3, 4),
+      svalue = c(1, 1, 1)
+    )
   )
   expect_identical(
     tidy(nlists(nlist(y = 1, s = 1:2))),
-    tibble::tibble(term = term("y", s = 2), estimate = c(1, 1, 2), sd = c(
-      NA_real_, NA_real_,
-      NA_real_
-    ), zscore = c(NA_real_, NA_real_, NA_real_), lower = c(
-      1,
-      1, 2
-    ), upper = c(1, 1, 2), svalue = c(1, 1, 1))
+    tibble::tibble(
+      term = term("y", s = 2),
+      estimate = c(1, 1, 2),
+      sd = c(
+        NA_real_,
+        NA_real_,
+        NA_real_
+      ),
+      zscore = c(NA_real_, NA_real_, NA_real_),
+      lower = c(
+        1,
+        1,
+        2
+      ),
+      upper = c(1, 1, 2),
+      svalue = c(1, 1, 1)
+    )
   )
-  expect_equal(tidy(nlists(nlist(x = 1, y = 1:2), nlist(x = 1, y = 3:4))), tibble::tibble(term = term("x" = 1, y = 2), estimate = c(1, 2, 3), sd = c(
-    0, 1.4142135623731,
-    1.4142135623731
-  ), zscore = c(Inf, 1.41421356237309, 2.12132034355964), lower = c(1, 1.05, 2.05), upper = c(1, 2.95, 3.95), svalue = c(
-    1.58496250072116,
-    1.58496250072116, 1.58496250072116
-  )))
+  expect_equal(
+    tidy(nlists(nlist(x = 1, y = 1:2), nlist(x = 1, y = 3:4))),
+    tibble::tibble(
+      term = term("x" = 1, y = 2),
+      estimate = c(1, 2, 3),
+      sd = c(
+        0,
+        1.4142135623731,
+        1.4142135623731
+      ),
+      zscore = c(Inf, 1.41421356237309, 2.12132034355964),
+      lower = c(1, 1.05, 2.05),
+      upper = c(1, 2.95, 3.95),
+      svalue = c(
+        1.58496250072116,
+        1.58496250072116,
+        1.58496250072116
+      )
+    )
+  )
 })
 
 test_that("tidy.nlists", {
-  expect_identical(tidy(nlists(), simplify = TRUE, directional_information = FALSE), structure(list(
-    term = structure(character(0), class = c(
-      "term",
-      "vctrs_vctr"
-    )), estimate = numeric(0),
-    lower = numeric(0), upper = numeric(0), svalue = numeric(0)
-  ), row.names = integer(0), class = c(
-    "tbl_df",
-    "tbl", "data.frame"
-  )))
+  expect_identical(
+    tidy(nlists(), simplify = TRUE, directional_information = FALSE),
+    structure(
+      list(
+        term = structure(
+          character(0),
+          class = c(
+            "term",
+            "vctrs_vctr"
+          )
+        ),
+        estimate = numeric(0),
+        lower = numeric(0),
+        upper = numeric(0),
+        svalue = numeric(0)
+      ),
+      row.names = integer(0),
+      class = c(
+        "tbl_df",
+        "tbl",
+        "data.frame"
+      )
+    )
+  )
   expect_equal(
     tidy(nlists(nlist()), simplify = TRUE, directional_information = FALSE),
     tibble::tibble(
-      term = term(x = 0), estimate = numeric(0),
-      lower = numeric(0), upper = numeric(0), svalue = numeric(0)
+      term = term(x = 0),
+      estimate = numeric(0),
+      lower = numeric(0),
+      upper = numeric(0),
+      svalue = numeric(0)
     )
   )
   expect_identical(
-    tidy(nlists(nlist(x = 2)), simplify = TRUE, directional_information = FALSE),
+    tidy(
+      nlists(nlist(x = 2)),
+      simplify = TRUE,
+      directional_information = FALSE
+    ),
     tibble::tibble(
-      term = term("x"), estimate = 2, lower = 2,
-      upper = 2, svalue = 1
+      term = term("x"),
+      estimate = 2,
+      lower = 2,
+      upper = 2,
+      svalue = 1
     )
   )
   expect_identical(
-    tidy(nlists(nlist(x = 2:4)), simplify = TRUE, directional_information = FALSE),
+    tidy(
+      nlists(nlist(x = 2:4)),
+      simplify = TRUE,
+      directional_information = FALSE
+    ),
     tibble::tibble(
-      term = term(x = 3), estimate = c(2, 3, 4),
+      term = term(x = 3),
+      estimate = c(2, 3, 4),
       lower = c(
         2,
-        3, 4
-      ), upper = c(2, 3, 4), svalue = c(1, 1, 1)
+        3,
+        4
+      ),
+      upper = c(2, 3, 4),
+      svalue = c(1, 1, 1)
     )
   )
   expect_identical(
-    tidy(nlists(nlist(y = 1, s = 1:2)), simplify = TRUE, directional_information = FALSE),
+    tidy(
+      nlists(nlist(y = 1, s = 1:2)),
+      simplify = TRUE,
+      directional_information = FALSE
+    ),
     tibble::tibble(
-      term = term("y", s = 2), estimate = c(1, 1, 2),
+      term = term("y", s = 2),
+      estimate = c(1, 1, 2),
       lower = c(
         1,
-        1, 2
-      ), upper = c(1, 1, 2), svalue = c(1, 1, 1)
+        1,
+        2
+      ),
+      upper = c(1, 1, 2),
+      svalue = c(1, 1, 1)
     )
   )
-  expect_equal(tidy(nlists(nlist(x = 1, y = 1:2), nlist(x = 1, y = 3:4)), simplify = TRUE, directional_information = FALSE), tibble::tibble(
-    term = term("x" = 1, y = 2), estimate = c(1, 2, 3),
-    lower = c(1, 1.05, 2.05), upper = c(1, 2.95, 3.95), svalue = c(
-      1.58496250072116,
-      1.58496250072116, 1.58496250072116
+  expect_equal(
+    tidy(
+      nlists(nlist(x = 1, y = 1:2), nlist(x = 1, y = 3:4)),
+      simplify = TRUE,
+      directional_information = FALSE
+    ),
+    tibble::tibble(
+      term = term("x" = 1, y = 2),
+      estimate = c(1, 2, 3),
+      lower = c(1, 1.05, 2.05),
+      upper = c(1, 2.95, 3.95),
+      svalue = c(
+        1.58496250072116,
+        1.58496250072116,
+        1.58496250072116
+      )
     )
-  ))
+  )
 })
 
 test_that("tidy.mcmc", {
@@ -125,7 +235,11 @@ test_that("tidy.mcmc.list", {
 
   nlists <- nlists(nlist(x = 1:3, y = matrix(1)))
   expect_identical(
-    tidy(as_mcmc_list(nlists), simplify = TRUE, directional_information = FALSE),
+    tidy(
+      as_mcmc_list(nlists),
+      simplify = TRUE,
+      directional_information = FALSE
+    ),
     tidy(nlists, simplify = TRUE, directional_information = FALSE)
   )
 })
@@ -135,15 +249,26 @@ test_that("tidy directional_information = TRUE", {
   tidy_di <- tidy(x, simplify = TRUE, directional_information = TRUE)
   tidy_svalue <- tidy(x, simplify = TRUE, directional_information = FALSE)
 
-  expect_identical(colnames(tidy_di), c("term", "estimate", "lower", "upper", "svalue"))
+  expect_identical(
+    colnames(tidy_di),
+    c("term", "estimate", "lower", "upper", "svalue")
+  )
   expect_identical(
     tidy_di[c("term", "estimate", "lower", "upper")],
     tidy_svalue[c("term", "estimate", "lower", "upper")]
   )
-  expect_identical(tidy_di$svalue[tidy_di$term == "x"], extras::directional_information(c(1, 3)))
-  expect_identical(tidy_di$svalue[tidy_di$term == "y"], extras::directional_information(c(-2, -4)))
-  expect_identical(tidy_svalue$svalue[tidy_svalue$term == "x"], extras::svalue(c(1, 3)))
-
+  expect_identical(
+    tidy_di$svalue[tidy_di$term == "x"],
+    extras::directional_information(c(1, 3))
+  )
+  expect_identical(
+    tidy_di$svalue[tidy_di$term == "y"],
+    extras::directional_information(c(-2, -4))
+  )
+  expect_identical(
+    tidy_svalue$svalue[tidy_svalue$term == "x"],
+    extras::svalue(c(1, 3))
+  )
 })
 
 test_that("tidy directional_information = TRUE with simplify = FALSE", {

--- a/tests/testthat/tests-fill-all.R
+++ b/tests/testthat/tests-fill-all.R
@@ -1,25 +1,61 @@
 test_that("", {
   expect_identical(
     fill_all(nlist(x = c(2, NA), y = matrix(c(1:3, NA), nrow = 2))),
-    structure(list(x = c(0, 0), y = structure(c(0L, 0L, 0L, 0L), .Dim = c(
-      2L,
-      2L
-    ))), class = "nlist")
+    structure(
+      list(
+        x = c(0, 0),
+        y = structure(
+          c(0L, 0L, 0L, 0L),
+          .Dim = c(
+            2L,
+            2L
+          )
+        )
+      ),
+      class = "nlist"
+    )
   )
-  expect_identical(fill_all(nlist(x = c(2, NA), y = matrix(c(1:3, NA), nrow = 2)), nas = FALSE), structure(list(x = c(0, NA), y = structure(c(0L, 0L, 0L, NA), .Dim = c(
-    2L,
-    2L
-  ))), class = "nlist"))
+  expect_identical(
+    fill_all(
+      nlist(x = c(2, NA), y = matrix(c(1:3, NA), nrow = 2)),
+      nas = FALSE
+    ),
+    structure(
+      list(
+        x = c(0, NA),
+        y = structure(
+          c(0L, 0L, 0L, NA),
+          .Dim = c(
+            2L,
+            2L
+          )
+        )
+      ),
+      class = "nlist"
+    )
+  )
 
   expect_identical(
     fill_all(nlists(nlist(x = c(2, NA)), nlist(x = c(NA_real_, NA)))),
-    structure(list(
-      structure(list(x = c(0, 0)), class = "nlist"),
-      structure(list(x = c(0, 0)), class = "nlist")
-    ), class = "nlists")
+    structure(
+      list(
+        structure(list(x = c(0, 0)), class = "nlist"),
+        structure(list(x = c(0, 0)), class = "nlist")
+      ),
+      class = "nlists"
+    )
   )
-  expect_identical(fill_all(nlists(nlist(x = c(2, NA)), nlist(x = c(NA_real_, NA))), nas = FALSE), structure(list(
-    structure(list(x = c(0, NA)), class = "nlist"),
-    structure(list(x = c(NA_real_, NA_real_)), class = "nlist")
-  ), class = "nlists"))
+  expect_identical(
+    fill_all(
+      nlists(nlist(x = c(2, NA)), nlist(x = c(NA_real_, NA))),
+      nas = FALSE
+    ),
+    structure(
+      list(
+        structure(list(x = c(0, NA)), class = "nlist"),
+        structure(list(x = c(NA_real_, NA_real_)), class = "nlist")
+      ),
+      class = "nlists"
+    )
+  )
 })


### PR DESCRIPTION
Adds air formatting following the org standard (as in `chk`):

- `air.toml` with the standard `[format]` settings
- `.vscode/` settings recommending and enabling format-on-save with Posit air
- `.Rbuildignore` entries for `air.toml` and `.vscode`
- All R source formatted with `air format .` (air 0.9.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)