### PR TITLE
Fix `subset.nlists()` to range-check `iters` argument

### DIFF
--- a/R/subset.R
+++ b/R/subset.R
@@ -174,7 +174,7 @@ subset.nlists <- function(x, chains = NULL, iters = NULL, pars = NULL, ...) {
     chk_subset(chains, 1:nchains(x))
   }
   if (!is.null(iters)) {
-    chk_subset(chains, 1:niters(x))
+    chk_subset(iters, 1:niters(x))
   }
   if (!is.null(pars)) {
     chk_subset(pars, pars(x))

--- a/tests/testthat/test-subset.R
+++ b/tests/testthat/test-subset.R
@@ -160,6 +160,11 @@ test_that("subset.nlists pars and iters", {
     "^`pars` must match 'x' or 'y', not 'z'[.]$",
     class = "chk_error"
   )
+  expect_error(
+    subset(nlists(nlist(x = 1), nlist(x = 2)), iters = 3L),
+    "`iters` must match",
+    class = "chk_error"
+  )
 })
 
 


### PR DESCRIPTION
`subset.nlists()` called `chk_subset(chains, 1:niters(x))` inside the `iters` branch, so the `iters` argument was never range-checked. Out-of-range values failed obscurely in `as_nlists()` (or could silently produce NA-padded results) instead of raising an informative chk error.

- Fixed the check to `chk_subset(iters, 1:niters(x))`.
- Added a regression test that out-of-range `iters` raises a `chk_error`.

`devtools::test()`: 450 passed, 0 failed (1 pre-existing skip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)