### PR TITLE
Add test coverage for mcmc and mcmc.list methods

### DIFF
--- a/tests/testthat/test-bind-iterations.R
+++ b/tests/testthat/test-bind-iterations.R
@@ -1,0 +1,66 @@
+test_that("bind_iterations.mcmc", {
+  expect_equal(
+    bind_iterations(as_mcmc(nlist(x = 1)), as_mcmc(nlist(x = 3))),
+    as_mcmc(nlists(nlist(x = 1), nlist(x = 3))),
+    ignore_attr = TRUE
+  )
+  expect_identical(
+    niters(bind_iterations(as_mcmc(nlist(x = 1)), as_mcmc(nlist(x = 3)))),
+    2L
+  )
+  expect_error(
+    bind_iterations(as_mcmc(nlist(x = 1)), 1),
+    "^`x2` must inherit from S3 class 'mcmc'",
+    class = "chk_error"
+  )
+  expect_error(
+    bind_iterations(as_mcmc(nlist(x = 1)), as_mcmc(nlist(y = 1))),
+    "^`x` and `x2` must have the same parameters[.]$",
+    class = "chk_error"
+  )
+  expect_error(
+    bind_iterations(as_mcmc(nlist(x = 1)), as_mcmc(nlist(x = 1:2))),
+    "^`x` and `x2` must have the same parameter dimensions[.]$",
+    class = "chk_error"
+  )
+})
+
+test_that("bind_iterations.mcmc.list", {
+  expect_equal(
+    bind_iterations(as_mcmc_list(nlist(x = 1)), as_mcmc_list(nlist(x = 3))),
+    as_mcmc_list(nlists(nlist(x = 1), nlist(x = 3))),
+    ignore_attr = TRUE
+  )
+
+  mcmc_list <- as_mcmc_list(split_chains(nlists(nlist(x = 1), nlist(x = 2))))
+  mcmc_list2 <- as_mcmc_list(split_chains(nlists(nlist(x = 5), nlist(x = 6))))
+  bound <- bind_iterations(mcmc_list, mcmc_list2)
+  expect_identical(nchains(bound), 2L)
+  expect_identical(niters(bound), 2L)
+  expect_equal(
+    bound,
+    as_mcmc_list(split_chains(nlists(
+      nlist(x = 1),
+      nlist(x = 5),
+      nlist(x = 2),
+      nlist(x = 6)
+    ))),
+    ignore_attr = TRUE
+  )
+
+  expect_error(
+    bind_iterations(mcmc_list, as_mcmc_list(nlist(x = 3))),
+    "^`x` and `x2` must have the same number of chains[.]$",
+    class = "chk_error"
+  )
+  expect_error(
+    bind_iterations(as_mcmc_list(nlist(x = 1)), as_mcmc_list(nlist(y = 1))),
+    "^`x` and `x2` must have the same parameters[.]$",
+    class = "chk_error"
+  )
+  expect_error(
+    bind_iterations(as_mcmc_list(nlist(x = 1)), as_mcmc_list(nlist(x = 1:2))),
+    "^`x` and `x2` must have the same parameter dimensions[.]$",
+    class = "chk_error"
+  )
+})

--- a/tests/testthat/test-is.R
+++ b/tests/testthat/test-is.R
@@ -1,3 +1,11 @@
+test_that("is_numeric", {
+  expect_true(is_numeric(1))
+  expect_true(is_numeric(1:2))
+  expect_true(is_numeric(matrix(1:4, 2)))
+  expect_false(is_numeric("1"))
+  expect_false(is_numeric(list(x = 1)))
+})
+
 test_that("is_nlist", {
   expect_false(is_nlist(1))
   expect_false(is_nlist(list(x = 1)))

--- a/tests/testthat/test-niters.R
+++ b/tests/testthat/test-niters.R
@@ -3,8 +3,14 @@ test_that("niters nlist", {
   expect_identical(niters(nlist(x = 1)), 1L)
 })
 
-test_that("", {
+test_that("niters nlists", {
   expect_identical(niters(nlists()), 0L)
   expect_identical(nsims(nlists(nlist())), 1L)
   expect_identical(nsims(nlists(nlist(), nlist())), 2L)
+})
+
+test_that("niters mcmc and mcmc.list", {
+  expect_identical(niters(as_mcmc(nlist(x = 1))), 1L)
+  expect_identical(niters(as_mcmc(nlists(nlist(x = 1), nlist(x = 2)))), 2L)
+  expect_identical(niters(as_mcmc_list(nlist(x = 1))), 1L)
 })

--- a/tests/testthat/test-pars.R
+++ b/tests/testthat/test-pars.R
@@ -42,6 +42,22 @@ test_that("pars.nlists scalar", {
   )
 })
 
+test_that("pars.mcmc", {
+  mcmc <- as_mcmc(nlist(y = 1, a = 2:3))
+  expect_identical(pars(mcmc), c("y", "a"))
+  expect_identical(pars(mcmc, scalar = TRUE), "y")
+  expect_identical(pars(mcmc, scalar = FALSE), "a")
+  lifecycle::expect_defunct(pars(mcmc, terms = TRUE))
+})
+
+test_that("pars.mcmc.list", {
+  mcmc_list <- as_mcmc_list(nlist(y = 1, a = 2:3))
+  expect_identical(pars(mcmc_list), c("y", "a"))
+  expect_identical(pars(mcmc_list, scalar = TRUE), "y")
+  expect_identical(pars(mcmc_list, scalar = FALSE), "a")
+  lifecycle::expect_defunct(pars(mcmc_list, terms = TRUE))
+})
+
 test_that("pars.nlists term", {
   lifecycle::expect_defunct(pars(
     nlists(nlist(x = 1, a = 1:2)),

--- a/tests/testthat/test-print.R
+++ b/tests/testthat/test-print.R
@@ -1,5 +1,4 @@
 test_that("print.nlist", {
-  skip_on_covr()
   expect_identical(
     capture.output(print(nlist())),
     "an nlist object with 0 numeric elements"
@@ -25,7 +24,6 @@ test_that("print.nlist", {
 })
 
 test_that("print.nlists", {
-  skip_on_covr()
   expect_identical(
     capture.output(print(nlists())),
     "an nlists object with 0 nlist objects"
@@ -56,8 +54,6 @@ test_that("print.nlists", {
 })
 
 test_that("print.nlists multiple chains", {
-  skip_on_covr()
-
   nlist <- nlist(x = 1, y = matrix(1:4, 2))
   nlists <- nlists(nlist, nlist)
   attr(nlists, "nchains") <- 2L

--- a/tests/testthat/test-set-pars.R
+++ b/tests/testthat/test-set-pars.R
@@ -23,6 +23,22 @@ test_that("nlist", {
   )
 })
 
+test_that("mcmc", {
+  mcmc <- as_mcmc(nlist(y = 1, a = 2:3))
+  renamed <- set_pars(mcmc, c("b", "z"))
+  expect_s3_class(renamed, "mcmc")
+  expect_identical(colnames(renamed), c("b", "z[1]", "z[2]"))
+  expect_identical(pars(renamed), c("b", "z"))
+})
+
+test_that("mcmc.list", {
+  mcmc_list <- as_mcmc_list(nlist(y = 1, a = 2:3))
+  renamed <- set_pars(mcmc_list, c("b", "z"))
+  expect_s3_class(renamed, "mcmc.list")
+  expect_identical(colnames(renamed[[1]]), c("b", "z[1]", "z[2]"))
+  expect_identical(pars(renamed), c("b", "z"))
+})
+
 test_that("nlists", {
   x <- nlists()
   expect_identical(set_pars(x, character(0)), x)

--- a/tests/testthat/test-sort.R
+++ b/tests/testthat/test-sort.R
@@ -1,0 +1,14 @@
+test_that("sort.mcmc", {
+  mcmc <- as_mcmc(nlist(y = 1, a = 2:3))
+  sorted <- sort(mcmc)
+  expect_s3_class(sorted, "mcmc")
+  expect_identical(colnames(sorted), c("a[1]", "a[2]", "y"))
+  expect_identical(sort(sorted), sorted)
+})
+
+test_that("sort.mcmc.list", {
+  mcmc_list <- as_mcmc_list(nlist(y = 1, a = 2:3))
+  sorted <- sort(mcmc_list)
+  expect_s3_class(sorted, "mcmc.list")
+  expect_identical(colnames(sorted[[1]]), c("a[1]", "a[2]", "y"))
+})


### PR DESCRIPTION
Closes #40, closes #41, closes #42.

- `bind_iterations.mcmc()` and `bind_iterations.mcmc.list()`: binding single- and multi-chain objects, plus all `abort_chk()` error paths (mismatched parameters, parameter dimensions, and number of chains) - coverage was 33%.
- `pars.mcmc()` / `pars.mcmc.list()`: default, `scalar = TRUE/FALSE`, and the defunct `terms =` argument.
- `set_pars.mcmc()` / `set_pars.mcmc.list()`: renaming preserves class and term indices.
- `sort.mcmc()` / `sort.mcmc.list()`: previously untested file (50%).
- `niters.mcmc()` / `niters.mcmc.list()` and `is_numeric()`: small gaps surfaced by the coverage report.
- Removed `skip_on_covr()` from the print tests: they now pass under covr, so `print.R` counts toward coverage again (this pairs with the `.covrignore` cleanup in #57).

Package coverage rises from 93% to 96.5%; `bind-iterations.R`, `sort.R`, `pars.R`, `set-pars.R`, `niters.R`, `print.R` and `is.R` are all at 100%.

One observation while testing, left unchanged: in `bind_iterations.mcmc.list()` the `x2` class check is nested inside a test of `x`'s dims, so a non-mcmc `x2` falls through to the "must have the same parameters" error rather than the class error. It still errors informatively, but the guard looks like it was meant to test `x2`.

`devtools::check()`: 0 errors, 0 warnings, 0 notes. Tests: 459 passing (1 pre-existing skip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)